### PR TITLE
Prime ordering

### DIFF
--- a/Praefectus.Console/Application.fs
+++ b/Praefectus.Console/Application.fs
@@ -2,7 +2,7 @@
 
 open Serilog
 
-type Application = {
-    Config: Configuration
+type Application<'StorageState> when 'StorageState : equality = {
+    Config: Configuration<'StorageState>
     Logger: ILogger
 }

--- a/Praefectus.Console/Commands.fs
+++ b/Praefectus.Console/Commands.fs
@@ -33,8 +33,8 @@ let private printInstruction { Task = task; NewState = { FileSystemStorage.FileN
 
 let doSort (config: Configuration<FileSystemStorage.FileSystemTaskState>) (whatIf: bool): Async<unit> = async {
     let! database = MarkdownDirectory.readDatabase config.DatabaseLocation
-    let reorderedTasks = Ordering.reorder config.Ordering database.Tasks
-    let instructions = Ordering.applyOrderInStorage reorderedTasks
+    let reorderedTasks = Ordering.reorder config.Ordering database.Tasks |> Seq.toArray
+    let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState reorderedTasks
     if whatIf then
         instructions |> Seq.iter printInstruction
     else

--- a/Praefectus.Console/Commands.fs
+++ b/Praefectus.Console/Commands.fs
@@ -17,11 +17,26 @@ let private printTask task =
 
     printfn "%s : %s : %s" (print "ORDER" task.Order) (print "ID" task.Id) (print "NAME" task.Name)
 
-let doList (app: Application) (isJson: bool) (output: Stream): System.Threading.Tasks.Task<unit> = task {
+let doList (app: Application<FileSystemStorage.FileSystemTaskState>)
+           (isJson: bool)
+           (output: Stream): System.Threading.Tasks.Task<unit> = task {
     let! database = MarkdownDirectory.readDatabase app.Config.DatabaseLocation
     let tasks = database.Tasks
     if isJson then
         do! Json.serializeData tasks output
     else
         tasks |> orderTasks |> Seq.iter printTask
+}
+
+let private printInstruction { Task = task; NewState = { FileSystemStorage.FileName = newFileName } } =
+    printfn "%s -> %s" task.StorageState.FileName newFileName
+
+let doSort (config: Configuration<FileSystemStorage.FileSystemTaskState>) (whatIf: bool): Async<unit> = async {
+    let! database = MarkdownDirectory.readDatabase config.DatabaseLocation
+    let reorderedTasks = Ordering.reorder config.Ordering database.Tasks
+    let instructions = Ordering.applyOrderInStorage reorderedTasks
+    if whatIf then
+        instructions |> Seq.iter printInstruction
+    else
+        do! MarkdownDirectory.applyStorageInstructions config.DatabaseLocation instructions
 }

--- a/Praefectus.Console/Commands.fs
+++ b/Praefectus.Console/Commands.fs
@@ -31,7 +31,7 @@ let doList (app: Application<FileSystemStorage.FileSystemTaskState>)
 let private printInstruction { Task = task; NewState = { FileSystemStorage.FileName = newFileName } } =
     printfn "%s -> %s" task.StorageState.FileName newFileName
 
-let doSort (config: Configuration<FileSystemStorage.FileSystemTaskState>) (whatIf: bool): Async<unit> = async {
+let doOrder (config: Configuration<FileSystemStorage.FileSystemTaskState>) (whatIf: bool): Async<unit> = async {
     let! database = MarkdownDirectory.readDatabase config.DatabaseLocation
     let reorderedTasks = Ordering.reorder config.Ordering database.Tasks |> Seq.toArray
     let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState reorderedTasks

--- a/Praefectus.Console/Configuration.fs
+++ b/Praefectus.Console/Configuration.fs
@@ -1,7 +1,12 @@
 ﻿namespace Praefectus.Console
 
+open System.Collections.Generic
+
+open Praefectus.Core.Ordering
+
 /// Praefectus application configuration.
-type Configuration = {
+type Configuration<'StorageState> when 'StorageState : equality = {
     /// Location of the Praefectus storage directory.
     DatabaseLocation: string
+    Ordering: IReadOnlyCollection<TaskPredicate<'StorageState>>
 }

--- a/Praefectus.Console/EntryPoint.fs
+++ b/Praefectus.Console/EntryPoint.fs
@@ -79,6 +79,9 @@ let private execute application (arguments: ParseResults<Arguments>) stdOut =
                 | Arguments.List listArgs ->
                     let json = listArgs.Contains ListArguments.Json
                     Commands.doList application json stdOut |> Task.RunSynchronously
+                | Arguments.Sort sortArgs ->
+                    let whatIf = sortArgs.Contains SortArguments.WhatIf
+                    Commands.doSort application.Config whatIf |> Async.RunSynchronously
                 | other -> failwithf "Impossible: option %A passed as a subcommand" other
 
             ExitCodes.Success

--- a/Praefectus.Console/EntryPoint.fs
+++ b/Praefectus.Console/EntryPoint.fs
@@ -22,7 +22,7 @@ type ListArguments =
             match s with
             | Json -> "write output in JSON format."
 
-type SortArguments =
+type OrderArguments =
     | [<Unique>] WhatIf
     interface IArgParserTemplate with
         member s.Usage =
@@ -33,7 +33,7 @@ type SortArguments =
 type Arguments =
     | [<Unique>] Version
     | [<CliPrefix(CliPrefix.None)>] List of ParseResults<ListArguments>
-    | [<CliPrefix(CliPrefix.None)>] Sort of ParseResults<SortArguments>
+    | [<CliPrefix(CliPrefix.None)>] Order of ParseResults<OrderArguments>
     interface IArgParserTemplate with
         member s.Usage =
             match s with
@@ -42,7 +42,7 @@ type Arguments =
 
             // Commands:
             | List _ -> "List all the tasks in the database."
-            | Sort _ -> "Sort the tasks according to the configured ordering rules."
+            | Order _ -> "Order the tasks according to the configured ordering rules."
 
 [<MethodImpl(MethodImplOptions.NoInlining)>] // See https://github.com/dotnet/fsharp/issues/9283
 let getAppVersion(): Version =
@@ -79,9 +79,9 @@ let private execute application (arguments: ParseResults<Arguments>) stdOut =
                 | Arguments.List listArgs ->
                     let json = listArgs.Contains ListArguments.Json
                     Commands.doList application json stdOut |> Task.RunSynchronously
-                | Arguments.Sort sortArgs ->
-                    let whatIf = sortArgs.Contains SortArguments.WhatIf
-                    Commands.doSort application.Config whatIf |> Async.RunSynchronously
+                | Arguments.Order sortArgs ->
+                    let whatIf = sortArgs.Contains OrderArguments.WhatIf
+                    Commands.doOrder application.Config whatIf |> Async.RunSynchronously
                 | other -> failwithf "Impossible: option %A passed as a subcommand" other
 
             ExitCodes.Success

--- a/Praefectus.Core/Database.fs
+++ b/Praefectus.Core/Database.fs
@@ -2,11 +2,11 @@ namespace Praefectus.Core
 
 open System.Collections.Generic
 
-type Database = {
-    Tasks: IReadOnlyCollection<Task>
+type Database<'StorageState> when 'StorageState : equality = {
+    Tasks: IReadOnlyCollection<Task<'StorageState>>
 }
 
-module Database =
-    let defaultDatabase = {
-        Tasks = [||]
-    }
+type StorageInstruction<'StorageState> when 'StorageState : equality = {
+    Task: Task<'StorageState>
+    NewState: 'StorageState
+}

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -93,7 +93,7 @@
 /// Such conditionality breaks algorithm completely, and there's no easy way to fix it without changing the structure of
 /// the graph.
 ///
-/// For such constrained scenarios, the following graph modifications are suggested:
+/// For such constrained scenarios, the following graph modifications are proposed:
 ///
 /// 1. The initial sequence is considered with all the empty places within it. So, "1A 3C 4B 5D" becomes "1A 2_ 3C 4B
 ///    5D".

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -20,8 +20,8 @@
 ///   │  │  │  │ ╲│
 /// D ·──·──·──·──·
 ///
-/// The goal is to get to the bottom right corner, while traversing the edit graph. Horizontal movements (from left to
-/// right) correspond to deletions of the corresponding item of the initial sequence; vertical movements (from top to
+/// The goal is to get from the top left corner to the bottom right corner of the graph. Horizontal movements (from left
+/// to right) correspond to deletions of the corresponding item of the initial sequence; vertical movements (from top to
 /// bottom) correspond to insertions of an item from the target sequence; diagonal movements (only available in places
 /// where the initial and the target sequences match) correspond to leaving an item of the initial sequence.
 ///
@@ -31,8 +31,9 @@
 /// this project, this is insufficient. In reality, we could have additional constraints that forbid certain paths in
 /// the edit graph.
 ///
-/// Let's consider an example of converting file sequence 1A, 3C, 4B, 5D to order ABCD with a minimal amount of renames.
-/// The resulting file sequence has to be numbered, and no number should be repeated twice.
+/// Let's consider an example of applying the order ABCD to the initial file sequence "1A 3C 4B 5D" with a minimal
+/// amount of renames. The resulting file sequence has to be numbered in the target order, and no number should be
+/// repeated twice.
 ///
 ///  0   1A 3C 4B 5D
 ///   ·──·──·──·──·
@@ -50,11 +51,11 @@
 /// D ·──·──·──·──·
 ///
 /// In this graph, certain paths (marked as double lines ║) are forbidden, because they would lead to insertion of the
-/// file in between of pair of another two subsequent files, which would lead to us having to renumber the latter file
-/// anyway, which is essentially the same in complexity as removing a file and inserting a new one.
+/// file in between of two existing subsequent files, which would lead to us having to renumber the latter file anyway,
+/// which is essentially the same in complexity as removing a file and inserting a new one.
 ///
-/// In other words, any vertical movements in columns between 3 and 4 are forbidden, because after 3 there's already 4,
-/// and after 4 there's already 5, to we cannot insert anything for free, and the graph could be drawn as this:
+/// In other words, any vertical movements in columns 3 and 4 are forbidden, because after 3 there's already 4, and
+/// after 4 there's already 5, and we cannot insert anything there for free, so the graph could be drawn as this:
 ///
 ///  0   1A 3C 4B 5D
 ///   ·──·──·──·──·
@@ -84,13 +85,18 @@
 /// B ·  ·  ·
 /// …
 ///
+/// But any separate step of this path could freely be taken in other routes, if necessary, if no two steps are taken in
+/// this column across a route.
+///
 /// Such conditionality breaks algorithm completely, and there's no easy way to fix it without changing the structure of
 /// the graph.
 ///
 /// For such constrained scenarios, the following graph modifications are suggested:
+///
 /// 1. The initial sequence is considered with all the empty places within it. So, "1A 3C 4B 5D" becomes "1A 2_ 3C 4B
 ///    5D".
-/// 2. Diagonal movements from any item to an item marked with "_" is allowed (as if it was equal to any item).
+/// 2. Diagonal movement from any item to an item marked with "_" is allowed (as if such item was equal to any other
+///    item).
 /// 3. No vertical movements are allowed except for the rightmost column: insertions to any place should use diagonals
 ///    left by empty spaces, but after the last item of the initial sequence, unlimited amount of space is available.
 ///

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -1,0 +1,13 @@
+/// Implementation of the Eugene W. Myers diff algorithm [1].
+///
+/// [1]: Eugene W. Myers, An O(ND) Difference Algorithm and Its Variations: Algorithmica (1986), pp. 251-266
+/// (http://www.grantjenks.com/wiki/_media/ideas:diffalgorithmlcs.pdf)
+module Praefectus.Core.Diff
+
+type EditInstruction<'a> =
+    | DeleteItem
+    | InsertItem of 'a
+    | LeaveItem
+
+let diff (sequenceA: 'a seq) (sequenceB: 'a seq): EditInstruction<'a> seq =
+    failwith "TODO: implement"

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -4,10 +4,50 @@
 /// (http://www.grantjenks.com/wiki/_media/ideas:diffalgorithmlcs.pdf)
 module Praefectus.Core.Diff
 
+open System
+open System.Collections.Generic
+
 type EditInstruction<'a> =
     | DeleteItem
     | InsertItem of 'a
     | LeaveItem
 
+/// Fig. 2. The greedy LCS/SES algorithm.
+let shortestEditScriptLength (a: IReadOnlyList<_>) (b: IReadOnlyList<_>) =
+    let M = b.Count
+    let N = a.Count
+    let MAX = M + N
+
+    if MAX < 1 then 0 else
+
+    let mutable V = Array.CreateInstance(typeof<int>, [| MAX * 2 + 1 |], [| -MAX |])
+    let V_set (index: int) value = V.SetValue(value, index)
+    let V_get (index: int) = V.GetValue(index) :?> int
+
+    V_set 1 0
+    let mutable ses = None
+    let mutable D = 0
+    while D <= MAX && ses.IsNone do
+        for k in -D .. 2 .. D do
+            let mutable x =
+                if k = -D || (k <> D && V_get(k - 1) < V_get(k + 1)) then
+                    V_get(k + 1)
+                else
+                    V_get(k - 1) + 1
+            let mutable y = x - k
+            while x < N && y < M && a.[x] = b.[y] do
+                x <- x + 1
+                y <- y + 1
+            V_set k x
+            if x >= N && y >= M then
+                ses <- Some D
+        D <- D + 1
+
+    match ses with
+    | Some x -> x
+    | None ->
+        failwithf "Algorithmic error: length of shortest edit script is greater than %d" MAX
+
 let diff (sequenceA: 'a seq) (sequenceB: 'a seq): EditInstruction<'a> seq =
     failwith "TODO: implement"
+

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -81,9 +81,21 @@ let decypherBacktrace (sequenceA: IReadOnlyList<'a>) (sequenceB: IReadOnlyList<'
     }
 
 let diff (sequenceA: IReadOnlyList<'a>) (sequenceB: IReadOnlyList<'a>): EditInstruction<'a> seq =
-    let (sesLength, vHistory, lastK) = shortestEditScriptTrace sequenceA sequenceB
-
-    match Seq.tryLast vHistory with
-    | None -> Seq.empty
-    | Some lastLevel ->
-        failwith "TODO"
+    let forwardtrace = decypherBacktrace sequenceA sequenceB |> Seq.rev
+    seq {
+        let enumerator = forwardtrace.GetEnumerator()
+        enumerator.MoveNext() |> ignore // always should succeed
+        let mutable x, y = enumerator.Current
+        while enumerator.MoveNext() do
+            let x', y' = enumerator.Current
+            while x < x' || y < y' do
+                yield LeaveItem
+                x <- x + 1
+                y <- y + 1
+            while x < x' do
+                yield DeleteItem
+                x <- x + 1
+            while y < y' do
+                yield InsertItem sequenceB.[y]
+                y <- y + 1
+    }

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -108,4 +108,4 @@ let diff (sequenceA: IReadOnlyList<'a>) (sequenceB: IReadOnlyList<'a>): EditInst
                 yield LeaveItem
                 x <- x + 1
                 y <- y + 1
-    } |> Seq.toArray |> Seq.ofArray
+    }

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -37,39 +37,41 @@
 ///
 ///  0   1A 3C 4B 5D
 ///   ·──·──·──·──·
-///   │╲ │  ║  ║  │
-///   │ ╲│  ║  ║  │
+///   ║╲ │  ║  ║  │
+///   ║ ╲│  ║  ║  │
 /// A ·──·──·──·──·
-///   │  │  ║╲ ║  │
-///   │  │  ║ ╲║  │
+///   ║  │  ║╲ ║  │
+///   ║  │  ║ ╲║  │
 /// B ·──·──·──·──·
-///   │  │╲ ║  ║  │
-///   │  │ ╲║  ║  │
+///   ║  │╲ ║  ║  │
+///   ║  │ ╲║  ║  │
 /// C ·──·──·──·──·
-///   │  │  ║  ║╲ │
-///   │  │  ║  ║ ╲│
+///   ║  │  ║  ║╲ │
+///   ║  │  ║  ║ ╲│
 /// D ·──·──·──·──·
 ///
 /// In this graph, certain paths (marked as double lines ║) are forbidden, because they would lead to insertion of the
-/// file in between of two existing subsequent files, which would lead to us having to renumber the latter file anyway,
-/// which is essentially the same in complexity as removing a file and inserting a new one.
+/// file in between of two existing subsequent files (or with a number below 1), which would lead to us having to
+/// renumber the latter file anyway, which is essentially the same in complexity as removing a file and inserting a new
+/// one.
 ///
-/// In other words, any vertical movements in columns 3 and 4 are forbidden, because after 3 there's already 4, and
-/// after 4 there's already 5, and we cannot insert anything there for free, so the graph could be drawn as this:
+/// In other words, any vertical movements in columns 0, 3 and 4 are forbidden, because 1 is occupied, after 3 there's
+/// already 4, and after 4 there's already 5, and we cannot insert anything there for free, so the graph could be drawn
+/// as this:
 ///
 ///  0   1A 3C 4B 5D
 ///   ·──·──·──·──·
-///   │╲ │        │
-///   │ ╲│        │
+///    ╲ │        │
+///     ╲│        │
 /// A ·──·──·──·──·
-///   │  │   ╲    │
-///   │  │    ╲   │
+///      │   ╲    │
+///      │    ╲   │
 /// B ·──·──·──·──·
-///   │  │╲       │
-///   │  │ ╲      │
+///      │╲       │
+///      │ ╲      │
 /// C ·──·──·──·──·
-///   │  │      ╲ │
-///   │  │       ╲│
+///      │      ╲ │
+///      │       ╲│
 /// D ·──·──·──·──·
 ///
 /// But even this is not all. Some of the paths are conditionally forbidden. For example, this path is forbidden,
@@ -83,7 +85,7 @@
 ///      │
 ///      │
 /// B ·  ·  ·
-/// …
+/// ⋮
 ///
 /// But any separate step of this path could freely be taken in other routes, if necessary, if no two steps are taken in
 /// this column across a route.

--- a/Praefectus.Core/Diff.fs
+++ b/Praefectus.Core/Diff.fs
@@ -98,7 +98,7 @@ let diff (sequenceA: IReadOnlyList<'a>) (sequenceB: IReadOnlyList<'a>): EditInst
 
             let isOnSnake() = x' - x = y' - y
 
-            // Here, we're always looking for the end of a snake. Calculate whether snake starts from point to the
+            // Here, (x', y') always points towards the end of a snake. Calculate whether snake starts from point to the
             // right or to the bottom from the current point (x, y).
             //
             // Snake itself is a line y = y_0 + x

--- a/Praefectus.Core/Diff/Algorithms.fs
+++ b/Praefectus.Core/Diff/Algorithms.fs
@@ -162,38 +162,6 @@ let decypherBacktrace (sequenceA: IPositionedSequence<'a>) (sequenceB: IReadOnly
     let graph = EditGraph(sequenceA, sequenceB)
     upcast shortestEditBacktrace graph
 
-let myersGeneralized' (sequenceA: IPositionedSequence<'a>) (sequenceB: IReadOnlyList<'a>): EditInstruction<'a> seq =
-    let graph = EditGraph(sequenceA, sequenceB)
-    let forwardtrace = shortestEditBacktrace graph |> Seq.rev
-    seq {
-        let mutable x, y = 0, 0
-        for x', y' in forwardtrace do
-            let isOnSnake() = x' - x = y' - y
-
-            // Here, (x', y') always points towards the end of a snake. Calculate whether snake starts from point to the
-            // right or to the bottom from the current point (x, y).
-            //
-            // Snake itself is a line y = y_0 + x
-            let y_0 = y' - x'
-            let snake x = y_0 + x
-            let snakeToRight = snake x < y
-            let snakeToBottom = sequenceA.AllowedToInsertAtArbitraryPlaces && snake x > y
-
-            while snakeToRight && not(isOnSnake()) do
-                yield DeleteItem
-                x <- x + 1
-            while snakeToBottom && not(isOnSnake()) do
-                yield InsertItem sequenceB.[y]
-                y <- y + 1
-            while x < x' && y < y' do // snake body itself
-                yield
-                    match sequenceA.GetItem x with
-                    | Some _ -> LeaveItem
-                    | None -> InsertItem sequenceB.[y]
-
-                x <- x + 1
-                y <- y + 1
-    }
 let myersGeneralized (sequenceA: IPositionedSequence<'a>) (sequenceB: IReadOnlyList<'a>): EditInstruction<'a> seq =
     let graph = EditGraph(sequenceA, sequenceB)
     let rec traverse currentRoutes =

--- a/Praefectus.Core/Diff/Algorithms.fs
+++ b/Praefectus.Core/Diff/Algorithms.fs
@@ -131,22 +131,10 @@
 ///
 /// [1]: Eugene W. Myers, An O(ND) Difference Algorithm and Its Variations: Algorithmica (1986), pp. 251-266
 /// (http://www.grantjenks.com/wiki/_media/ideas:diffalgorithmlcs.pdf)
-module Praefectus.Core.Diff
+module Praefectus.Core.Diff.Algorithms
 
 open System
 open System.Collections.Generic
-
-type EditInstruction<'a> =
-    | DeleteItem
-    | InsertItem of 'a
-    | LeaveItem
-
-type IPositionedSequence<'a> =
-    // TODO: Drop this flag, since it is the only mode we use in production code
-    abstract AllowedToInsertAtArbitraryPlaces: bool
-    abstract MaxOrder: int
-    abstract GetItem: index: int -> 'a option
-    abstract AcceptsOn: index: int * item: 'a -> bool
 
 /// Fig. 2. The greedy LCS/SES algorithm [1].
 let shortestEditScriptTrace<'a when 'a : equality> (a: IPositionedSequence<'a>)
@@ -257,7 +245,7 @@ let decypherBacktrace (sequenceA: IPositionedSequence<'a>) (sequenceB: IReadOnly
                 k <- k'
     |]
 
-let diff (sequenceA: IPositionedSequence<'a>) (sequenceB: IReadOnlyList<'a>): EditInstruction<'a> seq =
+let myersGeneralized (sequenceA: IPositionedSequence<'a>) (sequenceB: IReadOnlyList<'a>): EditInstruction<'a> seq =
     let forwardtrace = decypherBacktrace sequenceA sequenceB |> Seq.rev
     seq {
         let mutable x, y = 0, 0

--- a/Praefectus.Core/Diff/EditGraph.fs
+++ b/Praefectus.Core/Diff/EditGraph.fs
@@ -13,7 +13,7 @@ type EditGraph<'a>(sequenceA: IPositionedSequence<'a>, sequenceB: IReadOnlyList<
 
     let allowedStepRight = function
     | [] -> failwith "Empty route detected"
-    | (x, y) :: _ -> (getItemA(x + 1)).IsSome
+    | (x, y) :: _ -> x < maxX
 
     let allowedStepDown = function
     | [] -> failwith "Empty route detected"
@@ -86,11 +86,13 @@ type EditGraph<'a>(sequenceA: IPositionedSequence<'a>, sequenceB: IReadOnlyList<
             let mutable x, y = 0, 0
             for targetX, targetY in route do
                 while x < targetX && y = targetY do
-                    yield DeleteItem
                     x <- x + 1
+                    match getItemA x with
+                    | Some _ -> yield DeleteItem
+                    | None -> ()
                 while x = targetX && y < targetY do
-                    yield InsertItem sequenceB.[y]
                     y <- y + 1
+                    yield InsertItem(getItemB y)
                 while x < targetX && y < targetY do
                     x <- x + 1
                     y <- y + 1

--- a/Praefectus.Core/Diff/EditGraph.fs
+++ b/Praefectus.Core/Diff/EditGraph.fs
@@ -1,0 +1,8 @@
+﻿namespace Praefectus.Core.Diff
+
+open System.Collections.Generic
+
+type EditGraphRoute = seq<struct (int * int)>
+
+type EditGraph<'a>(sequenceA: IPositionedSequence<'a>, sequenceB: IReadOnlyList<'a>) =
+    class end

--- a/Praefectus.Core/Diff/EditGraph.fs
+++ b/Praefectus.Core/Diff/EditGraph.fs
@@ -2,7 +2,100 @@
 
 open System.Collections.Generic
 
-type EditGraphRoute = seq<struct (int * int)>
+type EditGraphBacktrace = list<int * int>
 
 type EditGraph<'a>(sequenceA: IPositionedSequence<'a>, sequenceB: IReadOnlyList<'a>) =
-    class end
+    let maxX = sequenceA.MaxCoord
+    let maxY = sequenceB.Count
+
+    let getItemA coordX = sequenceA.GetItem coordX
+    let getItemB coordY = sequenceB.[coordY - 1]
+
+    let allowedStepRight = function
+    | [] -> failwith "Empty route detected"
+    | (x, y) :: _ -> (getItemA(x + 1)).IsSome
+
+    let allowedStepDown = function
+    | [] -> failwith "Empty route detected"
+    | (x, y) :: _ when sequenceA.AllowedToInsertAtArbitraryPlaces -> x <= maxX && y < maxY
+    | (x_1, y_1) :: (x_0, y_0) :: _ when not sequenceA.AllowedToInsertAtArbitraryPlaces && x_1 = x_0 + 1 && y_1 = y_0 ->
+        // only in case of previous step was a step right
+        x_1 <= maxX && y_1 < maxY
+    | (x, y) :: _ -> x = maxX && y < maxY
+    | _ -> false
+
+    let allowedDiagonalStep = function
+    | [] -> failwith "Empty route detected"
+    | (x, y) :: _ -> x < maxX && y < maxY && sequenceA.AcceptsOn(x + 1, getItemB(y + 1))
+
+    let makeDiagonalSteps = function
+    | [] -> failwith "Empty route detected"
+    | ((x, y) :: _) as route when allowedDiagonalStep route ->
+        let mutable newRoute = route
+        let mutable x, y = x, y
+        while allowedDiagonalStep newRoute do
+            x <- x + 1
+            y <- y + 1
+            newRoute <- (x, y) :: route
+        newRoute
+    | route -> route
+
+    let processDiagonalSteps initialRoute derivedRoutes =
+        seq {
+            if allowedDiagonalStep initialRoute then
+                yield makeDiagonalSteps initialRoute
+            yield! (derivedRoutes |> Seq.collect(fun route -> seq {
+                yield route // choose not to take diagonal step
+                if allowedDiagonalStep route then
+                    yield makeDiagonalSteps route
+            }))
+        }
+
+    let appendPossibleSteps = function
+    | [] -> failwith "Empty route detected"
+    | ((x, y) :: _) as route ->
+        seq {
+            if allowedStepRight route then
+                (x + 1, y) :: route
+            if allowedStepDown route then
+                (x, y + 1) :: route
+        } |> processDiagonalSteps route
+
+    let minifyBacktraces routes =
+        Seq.groupBy List.head routes
+        |> Seq.map(fun (_, group) -> Seq.head group)
+
+    let isFinishedRoute = function
+    | [] -> failwith "Empty route detected"
+    | (x, y) :: _ -> x = maxX && y = maxY
+
+    member _.InitialBacktraces(): EditGraphBacktrace seq =
+        let trace = [0, 0]
+        Seq.singleton(makeDiagonalSteps trace)
+
+    member _.StepAll(routes: EditGraphBacktrace seq): EditGraphBacktrace seq =
+        Seq.collect appendPossibleSteps routes
+        |> minifyBacktraces
+
+    member _.GetFinished(routes: EditGraphBacktrace seq): EditGraphBacktrace option =
+        Seq.tryFind isFinishedRoute routes
+
+    member _.GetInstructions(route: EditGraphBacktrace): EditInstruction<'a> seq =
+        let route = Seq.rev route
+        seq {
+            let mutable x, y = 0, 0
+            for targetX, targetY in route do
+                while x < targetX && y = targetY do
+                    yield DeleteItem
+                    x <- x + 1
+                while x = targetX && y < targetY do
+                    yield InsertItem sequenceB.[y]
+                    y <- y + 1
+                while x < targetX && y < targetY do
+                    x <- x + 1
+                    y <- y + 1
+                    yield
+                        match getItemA x with
+                        | Some _ -> LeaveItem
+                        | None -> InsertItem(getItemB y)
+        }

--- a/Praefectus.Core/Diff/Types.fs
+++ b/Praefectus.Core/Diff/Types.fs
@@ -8,6 +8,6 @@ type EditInstruction<'a> =
 type IPositionedSequence<'a> =
     // TODO: Drop this flag, since it is the only mode we use in production code
     abstract AllowedToInsertAtArbitraryPlaces: bool
-    abstract MaxOrder: int
-    abstract GetItem: index: int -> 'a option
-    abstract AcceptsOn: index: int * item: 'a -> bool
+    abstract MaxCoord: int
+    abstract GetItem: coord: int -> 'a option
+    abstract AcceptsOn: coord: int * item: 'a -> bool

--- a/Praefectus.Core/Diff/Types.fs
+++ b/Praefectus.Core/Diff/Types.fs
@@ -1,0 +1,13 @@
+﻿namespace Praefectus.Core.Diff
+
+type EditInstruction<'a> =
+    | DeleteItem
+    | InsertItem of 'a
+    | LeaveItem
+
+type IPositionedSequence<'a> =
+    // TODO: Drop this flag, since it is the only mode we use in production code
+    abstract AllowedToInsertAtArbitraryPlaces: bool
+    abstract MaxOrder: int
+    abstract GetItem: index: int -> 'a option
+    abstract AcceptsOn: index: int * item: 'a -> bool

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -70,10 +70,11 @@ let applyOrderInStorage<'ss when 'ss : equality>(getNewState: int -> Task<'ss> -
                     currentFreeOrder <- currentTask.Order.Value + 1
             | Diff.InsertItem(newTask) ->
                 let newOrder = currentFreeOrder
-                let newState = getNewState newOrder newTask
-                yield {
-                    Task = { newTask with Order = Some newOrder }
-                    NewState = newState
-                }
+                if Some newOrder <> newTask.Order then
+                    let newState = getNewState newOrder newTask
+                    yield {
+                        Task = { newTask with Order = Some newOrder }
+                        NewState = newState
+                    }
                 currentFreeOrder <- newOrder + 1
     }

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -1,11 +1,18 @@
 module Praefectus.Core.Ordering
 
+open System.Collections.Generic
+
 type TaskPredicate<'ss> when 'ss : equality = Task<'ss> -> bool
 
 /// Reorders the tasks according to the ordering configured. Returns a collection in the right order, don't change the
 /// tasks' Order property.
-let reorder<'ss when 'ss : equality>(ordering: TaskPredicate<'ss> seq) (tasks: Task<'ss> seq): Task<'ss> seq =
-    failwith "TODO: implement"
+let reorder<'ss when 'ss : equality>(ordering: IReadOnlyCollection<TaskPredicate<'ss>>)
+                                    (tasks: Task<'ss> seq): Task<'ss> seq =
+    let getOrder task =
+        ordering
+        |> Seq.tryFindIndex (fun p -> p task)
+        |> Option.defaultValue ordering.Count // move any unmatched items to the end
+    Seq.sortBy getOrder tasks
 
 let applyOrderInStorage<'ss when 'ss : equality>(orderedTasks: Task<'ss> seq): StorageInstruction<'ss> seq =
     failwith "TODO: implement"

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -3,6 +3,8 @@ module Praefectus.Core.Ordering
 open System.Collections.Generic
 open System.Linq
 
+open Praefectus.Core.Diff.Algorithms
+
 type TaskPredicate<'ss> when 'ss : equality = Task<'ss> -> bool
 
 /// Reorders the tasks according to the ordering configured. Returns a collection in the right order, don't change the
@@ -49,7 +51,7 @@ let applyOrderInStorage<'ss when 'ss : equality>(getNewState: int -> Task<'ss> -
                                                 (orderedTasks: IReadOnlyList<Task<'ss>>): StorageInstruction<'ss> seq =
     let initialTasks = orderedTasks |> Seq.sortBy(fun t -> t.Order) |> Seq.toArray
     let positionedSequence = createPositionedSequence initialTasks
-    let instructions = Diff.diff positionedSequence orderedTasks
+    let instructions = myersGeneralized positionedSequence orderedTasks
     seq {
         use initialTaskEnumerator = (initialTasks :> IEnumerable<_>).GetEnumerator()
 

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -1,0 +1,11 @@
+module Praefectus.Core.Ordering
+
+type TaskPredicate<'ss> when 'ss : equality = Task<'ss> -> bool
+
+/// Reorders the tasks according to the ordering configured. Returns a collection in the right order, don't change the
+/// tasks' Order property.
+let reorder<'ss when 'ss : equality>(ordering: TaskPredicate<'ss> seq) (tasks: Task<'ss> seq): Task<'ss> seq =
+    failwith "TODO: implement"
+
+let applyOrderInStorage<'ss when 'ss : equality>(orderedTasks: Task<'ss> seq): StorageInstruction<'ss> seq =
+    failwith "TODO: implement"

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -24,7 +24,8 @@ let private createPositionedSequence tasks =
     let maxOrder = Seq.max orderDictionary.Values
     { new Diff.IPositionedSequence<_> with
         member _.MaxPosition = maxOrder
-        member _.AcceptsOn(position, item) =
+        member _.AcceptsOn(index, item) =
+            let position = index + 1
             if not(Set.contains position occupiedIndices) then true
             else
                 match orderDictionary.TryGetValue item with

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -20,7 +20,6 @@ let applyOrderInStorage<'ss when 'ss : equality>(getNewState: int -> Task<'ss> -
     let instructions = Diff.diff initialTasks orderedTasks
     seq {
         use initialTaskEnumerator = (initialTasks :> IEnumerable<_>).GetEnumerator()
-        initialTaskEnumerator.MoveNext() |> ignore
 
         let mutable currentFreeOrder = 1
         for instruction in instructions do

--- a/Praefectus.Core/Ordering.fs
+++ b/Praefectus.Core/Ordering.fs
@@ -29,21 +29,18 @@ let private createPositionedSequence (tasks: IReadOnlyList<Task<'a>>) =
     let occupiedIndices = Set.ofSeq orderDictionary.Values
     let maxOrder = Seq.max orderDictionary.Values
 
-    let indexToOrder i = i + 1
-
     { new Diff.IPositionedSequence<_> with
         member _.AllowedToInsertAtArbitraryPlaces = false
-        member _.MaxOrder = maxOrder
-        member _.GetItem index =
-            match itemDictionary.TryGetValue(indexToOrder index) with
+        member _.MaxCoord = maxOrder
+        member _.GetItem coord =
+            match itemDictionary.TryGetValue coord with
             | true, item -> Some item
             | false, _ -> None
-        member _.AcceptsOn(index, item) =
-            let position = indexToOrder index
-            if not(Set.contains position occupiedIndices) then true
+        member _.AcceptsOn(coord, item) =
+            if not(Set.contains coord occupiedIndices) then true
             else
                 match orderDictionary.TryGetValue item with
-                | true, order -> order = position
+                | true, order -> order = coord
                 | false, _ -> false
     }
 

--- a/Praefectus.Core/Praefectus.Core.fsproj
+++ b/Praefectus.Core/Praefectus.Core.fsproj
@@ -7,6 +7,7 @@
     <ItemGroup>
         <Compile Include="Tasks.fs" />
         <Compile Include="Database.fs" />
+        <Compile Include="Ordering.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Praefectus.Core/Praefectus.Core.fsproj
+++ b/Praefectus.Core/Praefectus.Core.fsproj
@@ -5,9 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Diff\Types.fs" />
+        <Compile Include="Diff\EditGraph.fs" />
+        <Compile Include="Diff\Algorithms.fs" />
         <Compile Include="Tasks.fs" />
         <Compile Include="Database.fs" />
-        <Compile Include="Diff.fs" />
         <Compile Include="Ordering.fs" />
     </ItemGroup>
 

--- a/Praefectus.Core/Praefectus.Core.fsproj
+++ b/Praefectus.Core/Praefectus.Core.fsproj
@@ -8,6 +8,7 @@
         <Compile Include="Tasks.fs" />
         <Compile Include="Database.fs" />
         <Compile Include="Ordering.fs" />
+        <Compile Include="Diff.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Praefectus.Core/Praefectus.Core.fsproj
+++ b/Praefectus.Core/Praefectus.Core.fsproj
@@ -7,8 +7,8 @@
     <ItemGroup>
         <Compile Include="Tasks.fs" />
         <Compile Include="Database.fs" />
-        <Compile Include="Ordering.fs" />
         <Compile Include="Diff.fs" />
+        <Compile Include="Ordering.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Praefectus.Example/Program.fs
+++ b/Praefectus.Example/Program.fs
@@ -6,6 +6,9 @@ open Praefectus.Console
 
 [<EntryPoint>]
 let main (argv: string[]): int =
-    let config = { DatabaseLocation = Environment.CurrentDirectory }
+    let config = {
+        DatabaseLocation = Environment.CurrentDirectory
+        Ordering = [|  |]
+    }
     use env = Environment.OpenStandard()
     EntryPoint.run config argv env

--- a/Praefectus.Example/Program.fs
+++ b/Praefectus.Example/Program.fs
@@ -10,7 +10,6 @@ let main (argv: string[]): int =
         DatabaseLocation = Environment.CurrentDirectory
         Ordering = [|
             fun t -> t.Name.Value.StartsWith("important")
-            fun other -> true
         |]
     }
     use env = Environment.OpenStandard()

--- a/Praefectus.Example/Program.fs
+++ b/Praefectus.Example/Program.fs
@@ -8,7 +8,10 @@ open Praefectus.Console
 let main (argv: string[]): int =
     let config = {
         DatabaseLocation = Environment.CurrentDirectory
-        Ordering = [|  |]
+        Ordering = [|
+            fun t -> t.Name.Value.StartsWith("important")
+            fun other -> true
+        |]
     }
     use env = Environment.OpenStandard()
     EntryPoint.run config argv env

--- a/Praefectus.Storage/FileSystemStorage.fs
+++ b/Praefectus.Storage/FileSystemStorage.fs
@@ -1,0 +1,51 @@
+module Praefectus.Storage.FileSystemStorage
+
+open System
+open System.Globalization
+open System.IO
+open System.Text
+
+open Praefectus.Core
+
+let generateFileName(task: Task<_>): string =
+    let append (x: string option) (builder: StringBuilder) =
+        match x with
+        | Some(x: string) -> builder.AppendFormat("{0}.", x)
+        | None -> builder
+
+    (StringBuilder()
+    |> append(task.Order |> Option.map string)
+    |> append task.Id
+    |> append task.Name)
+        .Append("md")
+        .ToString()
+
+type FileSystemTaskState = {
+    FileName: string
+}
+
+let readMetadata(path: string): FileSystemTaskState = {
+    FileName = Path.GetFileName path
+}
+
+type FsAttributes = { Order: int option; Name: string option; Id: string option }
+
+let readFsAttributes(filePath: string): FsAttributes =
+    let fileName = Path.GetFileNameWithoutExtension filePath
+    let components = fileName.Split(".")
+    match components.Length with
+    | 0 -> { Order = None; Id = None; Name = None }
+    | _ ->
+        let (order, idIndex) =
+            match Int32.TryParse(components.[0], NumberStyles.None, CultureInfo.InvariantCulture) with
+            | (true, order) -> (Some order, 1)
+            | (false, _) -> (None, 0)
+
+        let (name, id) =
+            match components.Length - idIndex with
+            | 0 -> None, None
+            | 1 -> None, Some components.[idIndex]
+            | _ -> Some components.[idIndex], Some <| String.Join('.', Seq.skip (idIndex + 1) components)
+
+        { Order = order; Name = name; Id = id }
+

--- a/Praefectus.Storage/FileSystemStorage.fs
+++ b/Praefectus.Storage/FileSystemStorage.fs
@@ -40,16 +40,16 @@ let readFsAttributes(filePath: string): FsAttributes =
     match components.Length with
     | 0 -> { Order = None; Id = None; Name = None }
     | _ ->
-        let (order, idIndex) =
+        let (order, nextIndex) =
             match Int32.TryParse(components.[0], NumberStyles.None, CultureInfo.InvariantCulture) with
             | (true, order) -> (Some order, 1)
             | (false, _) -> (None, 0)
 
-        let (name, id) =
-            match components.Length - idIndex with
+        let (id, name) =
+            match components.Length - nextIndex with
             | 0 -> None, None
-            | 1 -> None, Some components.[idIndex]
-            | _ -> Some components.[idIndex], Some <| String.Join('.', Seq.skip (idIndex + 1) components)
+            | 1 -> None, Some components.[nextIndex]
+            | _ -> Some components.[nextIndex], Some <| String.Join('.', Seq.skip (nextIndex + 1) components)
 
-        { Order = order; Name = name; Id = id }
+        { Order = order; Id = id; Name = name }
 

--- a/Praefectus.Storage/FileSystemStorage.fs
+++ b/Praefectus.Storage/FileSystemStorage.fs
@@ -16,7 +16,7 @@ let generateFileName(task: Task<_>): string =
     (StringBuilder()
     |> append(task.Order |> Option.map string)
     |> append task.Id
-    |> append task.Name)
+    |> append (task.Name |> Option.orElse(Some "")))
         .Append("md")
         .ToString()
 

--- a/Praefectus.Storage/FileSystemStorage.fs
+++ b/Praefectus.Storage/FileSystemStorage.fs
@@ -28,6 +28,10 @@ let readMetadata(path: string): FileSystemTaskState = {
     FileName = Path.GetFileName path
 }
 
+let getNewState(order: int) (task: Task<FileSystemTaskState>): FileSystemTaskState =
+    let newTask = { task with Order = Some order }
+    { FileName = generateFileName newTask }
+
 type FsAttributes = { Order: int option; Name: string option; Id: string option }
 
 let readFsAttributes(filePath: string): FsAttributes =

--- a/Praefectus.Storage/FileSystemStorage.fs
+++ b/Praefectus.Storage/FileSystemStorage.fs
@@ -16,7 +16,7 @@ let generateFileName(task: Task<_>): string =
     (StringBuilder()
     |> append(task.Order |> Option.map string)
     |> append task.Id
-    |> append (task.Name |> Option.orElse(Some "")))
+    |> append task.Name)
         .Append("md")
         .ToString()
 
@@ -36,20 +36,21 @@ type FsAttributes = { Order: int option; Name: string option; Id: string option 
 
 let readFsAttributes(filePath: string): FsAttributes =
     let fileName = Path.GetFileNameWithoutExtension filePath
-    let components = fileName.Split(".")
+    let components = fileName.Split "."
     match components.Length with
-    | 0 -> { Order = None; Id = None; Name = None }
+    | 0 -> failwith "Impossible"
     | _ ->
-        let (order, nextIndex) =
+        let order, idIndex =
             match Int32.TryParse(components.[0], NumberStyles.None, CultureInfo.InvariantCulture) with
-            | (true, order) -> (Some order, 1)
-            | (false, _) -> (None, 0)
+            | true, order -> (Some order, 1)
+            | false, _ -> (None, 0)
 
-        let (id, name) =
-            match components.Length - nextIndex with
+        let freeComponents = components.Length - idIndex
+        let id, name =
+            match freeComponents with
             | 0 -> None, None
-            | 1 -> None, Some components.[nextIndex]
-            | _ -> Some components.[nextIndex], Some <| String.Join('.', Seq.skip (nextIndex + 1) components)
+            | 1 -> Some components.[idIndex], None
+            | _ -> Some components.[idIndex], Some <| String.Join('.', Seq.skip (idIndex + 1) components)
 
         { Order = order; Id = id; Name = name }
 

--- a/Praefectus.Storage/Json.fs
+++ b/Praefectus.Storage/Json.fs
@@ -1,18 +1,17 @@
 ﻿module Praefectus.Storage.Json
 
 open System.IO
-open System.Threading.Tasks
 
 open FSharp.Control.Tasks
 open Newtonsoft.Json
 
 open Praefectus.Core
 
-let serializeData (data: 'a) (output: Stream): Task<unit> = task {
+let serializeData (data: 'a) (output: Stream): System.Threading.Tasks.Task<unit> = task {
     let serializer = JsonSerializer(Formatting = Formatting.Indented)
     use writer = new StreamWriter(output, leaveOpen = true)
     serializer.Serialize(writer, data)
 }
 
-let save (database: Database) (target: Stream): Task<unit> =
+let save (database: Database<_>) (target: Stream): System.Threading.Tasks.Task<unit> =
     serializeData database target

--- a/Praefectus.Storage/MarkdownDirectory.fs
+++ b/Praefectus.Storage/MarkdownDirectory.fs
@@ -168,9 +168,17 @@ let readDatabase (directory: string): Async<Database<FileSystemTaskState>> = asy
     return { Tasks = tasks }
 }
 
+let private applyInstruction databaseDirectory { Task = { StorageState = oldState }; NewState = newState } = async {
+    do! Async.SwitchToThreadPool()
+    let getPath state = Path.Combine(databaseDirectory, state.FileName)
+    File.Move(getPath oldState, getPath newState)
+}
+
 let applyStorageInstructions (databaseDirectory: string)
-                             (instructions: seq<StorageInstruction<FileSystemTaskState>>): Async<unit> =
-    failwith "TODO: implement"
+                             (instructions: seq<StorageInstruction<FileSystemTaskState>>): Async<unit> = async {
+    for instruction in instructions do
+        do! applyInstruction databaseDirectory instruction
+}
 
 let saveDatabase (database: Database<FileSystemTaskState>) (directory: string): Async<unit> = async {
     for task in database.Tasks do

--- a/Praefectus.Storage/Praefectus.Storage.fsproj
+++ b/Praefectus.Storage/Praefectus.Storage.fsproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <Compile Include="Json.fs" />
+        <Compile Include="FileSystemStorage.fs" />
         <Compile Include="MarkdownDirectory.fs" />
     </ItemGroup>
 

--- a/Praefectus.Tests/Console/DatabaseTests.fs
+++ b/Praefectus.Tests/Console/DatabaseTests.fs
@@ -27,7 +27,7 @@ let private testDatabase =
         Name = Some "name"
         Description = Some "description"
         DependsOn = Array.empty
-        StorageState = { FileName = "Test1.md" } } |] }
+        StorageState = { FileName = "42.Test1.name.md" } } |] }
 
 [<Fact>]
 let ``Database should be exported to JSON``(): System.Threading.Tasks.Task = upcast task {

--- a/Praefectus.Tests/Console/EntryPointTests.fs
+++ b/Praefectus.Tests/Console/EntryPointTests.fs
@@ -1,30 +1,38 @@
 module Praefectus.Tests.Console.EntryPointTests
 
+open System.IO
+
 open Xunit
 
+open Praefectus.Console
 open Praefectus.Console.EntryPoint
 open Praefectus.Tests.Console.ConsoleTestUtils
 
+let private testConfiguration = {
+    DatabaseLocation = Path.GetTempPath()
+    Ordering = Array.empty
+}
+
 [<Fact>]
 let ``Console should return code 2 without options``(): unit =
-    let exitCode = runMain [||]
+    let exitCode = runMain testConfiguration [||]
     Assert.Equal(ExitCodes.CannotParseArguments, exitCode)
 
 [<Fact>]
 let ``Console should return special code on unknown option``(): unit =
-    let exitCode = runMain [| "unknown" |]
+    let exitCode = runMain testConfiguration [| "unknown" |]
     Assert.Equal(ExitCodes.CannotParseArguments, exitCode)
 
 let ``Exit code should be zero if help was explicitly requested``(): unit =
-    let exitCode = runMain [| "--help" |]
+    let exitCode = runMain testConfiguration [| "--help" |]
     Assert.Equal(ExitCodes.Success, exitCode)
 
 [<Fact>]
 let ``Exit code should be zero if subcommand help was explicitly requested``(): unit =
-    let exitCode = runMain [| "list"; "--help" |]
+    let exitCode = runMain testConfiguration [| "list"; "--help" |]
     Assert.Equal(ExitCodes.Success, exitCode)
 
 [<Fact>]
 let ``Exit code signal a subcommand parse error``(): unit =
-    let exitCode = runMain [| "list"; "--unknown" |]
+    let exitCode = runMain testConfiguration [| "list"; "--unknown" |]
     Assert.Equal(ExitCodes.CannotParseArguments, exitCode)

--- a/Praefectus.Tests/Console/OrderCommandTests.fs
+++ b/Praefectus.Tests/Console/OrderCommandTests.fs
@@ -1,4 +1,4 @@
-module Praefectus.Tests.Console.CommandTests
+module Praefectus.Tests.Console.OrderCommandTests
 
 open Xunit
 
@@ -18,7 +18,7 @@ let readTasksAfterSort database sortOptions = Async.RunSynchronously <| async {
             fun t -> t.Id = Some "2"
         |]
     }
-    let exitCode = ConsoleTestUtils.runMain configuration [| "sort"; yield! sortOptions |]
+    let exitCode = ConsoleTestUtils.runMain configuration [| "order"; yield! sortOptions |]
     Assert.Equal(0, exitCode)
 
     let! database = MarkdownDirectory.readDatabase directory
@@ -49,13 +49,13 @@ let private sortedTasks = [|
 |]
 
 [<Fact>]
-let ``Sort command should reorder the data``(): unit =
+let ``Order command should reorder the data``(): unit =
     let database1 = { Tasks = unsortedTasks }
     let tasksAfterSort = readTasksAfterSort database1 Array.empty
     Assert.Equal(sortedTasks, tasksAfterSort)
 
 [<Fact>]
-let ``Sort command should not change anything if called with --whatif``(): unit =
+let ``Order command should not change anything if called with --whatif``(): unit =
     let database1 = { Tasks = unsortedTasks }
     let tasksAfterSort = readTasksAfterSort database1 [| "--whatif" |]
     Assert.Equal(unsortedTasks, tasksAfterSort)

--- a/Praefectus.Tests/Console/OrderCommandTests.fs
+++ b/Praefectus.Tests/Console/OrderCommandTests.fs
@@ -28,22 +28,22 @@ let readTasksAfterSort database sortOptions = Async.RunSynchronously <| async {
 let private emptyTask fileName =
     { Task.Empty<_> { FileName = fileName } with
         Description = Some ""
-        Name = Some "" }
+        Name = None }
 
 let private unsortedTasks = [|
-    { emptyTask "2.1..md" with
+    { emptyTask "2.1.md" with
         Order = Some 2
         Id = Some "1" }
-    { emptyTask "1.2..md" with
+    { emptyTask "1.2.md" with
         Order = Some 1
         Id = Some "2" }
 |]
 
 let private sortedTasks = [|
-    { emptyTask "2.1..md" with
+    { emptyTask "2.1.md" with
         Order = Some 2
         Id = Some "1" }
-    { emptyTask "3.2..md" with
+    { emptyTask "3.2.md" with
         Order = Some 3
         Id = Some "2" }
 |]

--- a/Praefectus.Tests/Console/SortCommandTests.fs
+++ b/Praefectus.Tests/Console/SortCommandTests.fs
@@ -25,20 +25,24 @@ let readTasksAfterSort database sortOptions = Async.RunSynchronously <| async {
     return database.Tasks
 }
 
+let private emptyTask fileName =
+    { Task.Empty<_> { FileName = fileName } with
+        Description = Some "" }
+
 let private unsortedTasks = [|
-    { Task.Empty<_> { FileName = "1.2.md" } with
+    { emptyTask "1.2.md" with
         Order = Some 1
         Id = Some "2" }
-    { Task.Empty<_> { FileName = "2.1.md" } with
+    { emptyTask "2.1.md" with
         Order = Some 2
         Id = Some "1" }
 |]
 
 let private sortedTasks = [|
-    { Task.Empty<_> { FileName = "2.1.md" } with
+    { emptyTask "2.1.md" with
         Order = Some 2
         Id = Some "1" }
-    { Task.Empty<_> { FileName = "3.2.md" } with
+    { emptyTask "3.2.md" with
         Order = Some 3
         Id = Some "2" }
 |]

--- a/Praefectus.Tests/Console/SortCommandTests.fs
+++ b/Praefectus.Tests/Console/SortCommandTests.fs
@@ -1,0 +1,56 @@
+module Praefectus.Tests.Console.CommandTests
+
+open Xunit
+
+open Praefectus.Core
+open Praefectus.Console
+open Praefectus.Storage
+open Praefectus.Storage.FileSystemStorage
+open Praefectus.Tests.TestFramework
+
+let readTasksAfterSort database sortOptions = Async.RunSynchronously <| async {
+    let! directory = DatabaseUtils.saveDatabaseToTempDirectory database
+
+    let configuration = {
+        DatabaseLocation = directory
+        Ordering = [|
+            fun t -> t.Id = Some "1"
+            fun t -> t.Id = Some "2"
+        |]
+    }
+    let exitCode = ConsoleTestUtils.runMain configuration [| "sort"; yield! sortOptions |]
+    Assert.Equal(0, exitCode)
+
+    let! database = MarkdownDirectory.readDatabase directory
+    return database.Tasks
+}
+
+let private unsortedTasks = [|
+    { Task.Empty<_> { FileName = "1.2.md" } with
+        Order = Some 1
+        Id = Some "2" }
+    { Task.Empty<_> { FileName = "2.1.md" } with
+        Order = Some 2
+        Id = Some "1" }
+|]
+
+let private sortedTasks = [|
+    { Task.Empty<_> { FileName = "2.1.md" } with
+        Order = Some 2
+        Id = Some "1" }
+    { Task.Empty<_> { FileName = "3.2.md" } with
+        Order = Some 3
+        Id = Some "2" }
+|]
+
+[<Fact>]
+let ``Sort command should reorder the data``(): unit =
+    let database1 = { Tasks = unsortedTasks }
+    let tasksAfterSort = readTasksAfterSort database1 Array.empty
+    Assert.Equal(sortedTasks, tasksAfterSort)
+
+[<Fact>]
+let ``Sort command should not change anything if called with --what-if``(): unit =
+    let database1 = { Tasks = unsortedTasks }
+    let tasksAfterSort = readTasksAfterSort database1 [| "--what-if" |]
+    Assert.Equal(unsortedTasks, tasksAfterSort)

--- a/Praefectus.Tests/Console/SortCommandTests.fs
+++ b/Praefectus.Tests/Console/SortCommandTests.fs
@@ -22,7 +22,7 @@ let readTasksAfterSort database sortOptions = Async.RunSynchronously <| async {
     Assert.Equal(0, exitCode)
 
     let! database = MarkdownDirectory.readDatabase directory
-    return database.Tasks
+    return database.Tasks |> Seq.sortBy(fun t -> t.Id)
 }
 
 let private emptyTask fileName =
@@ -31,12 +31,12 @@ let private emptyTask fileName =
         Name = Some "" }
 
 let private unsortedTasks = [|
-    { emptyTask "1.2..md" with
-        Order = Some 1
-        Id = Some "2" }
     { emptyTask "2.1..md" with
         Order = Some 2
         Id = Some "1" }
+    { emptyTask "1.2..md" with
+        Order = Some 1
+        Id = Some "2" }
 |]
 
 let private sortedTasks = [|

--- a/Praefectus.Tests/Console/SortCommandTests.fs
+++ b/Praefectus.Tests/Console/SortCommandTests.fs
@@ -27,22 +27,23 @@ let readTasksAfterSort database sortOptions = Async.RunSynchronously <| async {
 
 let private emptyTask fileName =
     { Task.Empty<_> { FileName = fileName } with
-        Description = Some "" }
+        Description = Some ""
+        Name = Some "" }
 
 let private unsortedTasks = [|
-    { emptyTask "1.2.md" with
+    { emptyTask "1.2..md" with
         Order = Some 1
         Id = Some "2" }
-    { emptyTask "2.1.md" with
+    { emptyTask "2.1..md" with
         Order = Some 2
         Id = Some "1" }
 |]
 
 let private sortedTasks = [|
-    { emptyTask "2.1.md" with
+    { emptyTask "2.1..md" with
         Order = Some 2
         Id = Some "1" }
-    { emptyTask "3.2.md" with
+    { emptyTask "3.2..md" with
         Order = Some 3
         Id = Some "2" }
 |]

--- a/Praefectus.Tests/Console/SortCommandTests.fs
+++ b/Praefectus.Tests/Console/SortCommandTests.fs
@@ -50,7 +50,7 @@ let ``Sort command should reorder the data``(): unit =
     Assert.Equal(sortedTasks, tasksAfterSort)
 
 [<Fact>]
-let ``Sort command should not change anything if called with --what-if``(): unit =
+let ``Sort command should not change anything if called with --whatif``(): unit =
     let database1 = { Tasks = unsortedTasks }
-    let tasksAfterSort = readTasksAfterSort database1 [| "--what-if" |]
+    let tasksAfterSort = readTasksAfterSort database1 [| "--whatif" |]
     Assert.Equal(unsortedTasks, tasksAfterSort)

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -117,7 +117,7 @@ let ``Decyphered backtrace for diff from paper``(): unit =
 let private doDiffTest initial required =
     let instructions = diff (Seq.toArray initial) (Seq.toArray required)
     let result = applyInstructions instructions initial |> Seq.toArray |> String
-    Assert.Equal(initial, result)
+    Assert.Equal(required, result)
 
 [<Fact>]
 let ``Diff test 0``(): unit = doDiffTest "ABCABBA" "CBABAC"

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -92,6 +92,16 @@ let ``Constrained shortest edit script test 1``(): unit =
         2, 'A'
     |] "AB" 1
 
+[<Fact>]
+let ``Constrained shortest edit script test 2``(): unit =
+    doConstrainedSesLengthTest [|
+        2, 'A'
+        4, 'D'
+        5, 'E'
+        6, 'B'
+        7, 'C'
+    |] "ABCDE" 4
+
 let private convertHistory a b array2d =
     let max = Array.length a + Array.length b
     array2d
@@ -153,7 +163,7 @@ let ``Trace array test from the paper``(): unit =
     assertHistoryEqual expectedHistory history
 
 let private assertDecypheredBacktraceEqual a b (expectedTrace: (int * int) seq) allowedToInsert =
-    let trace = decypherBacktrace a (Seq.toArray b)
+    let trace = decypherBacktrace a (Seq.toArray b) |> Seq.toArray
     Assert.Equal<int * int>(expectedTrace, trace)
 
 let private assertSimpleDecypheredBacktraceEqual a b expectedTrace =
@@ -201,6 +211,25 @@ let ``Constrained decyphered backtrace test 1``(): unit =
     |] "AB" [|
         3, 2
         0, 0
+    |]
+
+[<Fact>]
+let ``Constrained decyphered backtrace test 2``(): unit =
+    assertConditionalDecypheredBacktraceEqual [|
+        2, 'A'
+        4, 'D'
+        5, 'E'
+        6, 'F'
+        7, 'G'
+        8, 'B'
+        9, 'C'
+    |] "ABCDEFG" [|
+        9, 7
+        8, 7
+        7, 7
+        2, 2
+        2, 1
+        1, 1
     |]
 
 let private doDiffAndAssert initial target (initialString: string) allowedToInsert =
@@ -313,6 +342,18 @@ let ``Constrained diff test 8``(): unit =
         7, 'D'
         9, 'A'
     |] "0ABCD"
+
+[<Fact>]
+let ``Constrained diff test 9``(): unit =
+    doConstrainedDiffTest [|
+        2, 'A'
+        4, 'D'
+        5, 'E'
+        6, 'F'
+        7, 'G'
+        8, 'B'
+        9, 'C'
+    |] "ABCDEFG"
 
 let private doDiffInstructionTest initial required (initialString: string) expectedInstructions allowedToInsert =
     let instructions = doDiffAndAssert initial required initialString allowedToInsert

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -43,9 +43,10 @@ let private convertHistory a b array2d =
     |> Array.map (fun sampleArray ->
         let realArray = Array.CreateInstance(typeof<int>, [| max * 2 + 1 |], [| -max |])
         let offset = 1 - Array.length sampleArray
+        for i in -max..max do
+            realArray.SetValue(-1, i)
         sampleArray |> Array.iteri (fun i x ->
-            if x <> -1 then
-                realArray.SetValue(x, i * 2 + offset)
+            realArray.SetValue(x, i * 2 + offset)
         )
         realArray
     )
@@ -64,8 +65,13 @@ let private assertHistoryEqual (expected: Array[]) (actual: IReadOnlyList<Array>
         for k in lower..upper do
             let expectedItem = expectedStep.GetValue k :?> int
             let actualItem = actualStep.GetValue k :?> int
-            if expectedItem <> actualItem then
-                let expectedString = String.Join("; ", Seq.cast<int> expectedStep)
+            if expectedItem <> -1 && expectedItem <> actualItem then
+                let expectedStringified =
+                     expectedStep
+                     |> Seq.cast<int>
+                     |> Seq.map (fun x -> if x = -1 then "_" else string x)
+
+                let expectedString = String.Join("; ", expectedStringified)
                 let actualString = String.Join("; ", Seq.cast<int> actualStep)
                 let message = $"Historical arrays aren't equal at step {i}.\nExpected: [{expectedString}],\nactual:   [{actualString}]"
                 Assert.True(false, message)

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -50,7 +50,9 @@ let ``Simple shortest edit script test 4``(): unit = doSimpleSesLengthTest "abc"
 let ``Simple shortest edit script test 5``(): unit = doSimpleSesLengthTest "abcabc" "abc" 3
 
 let private createPositionedSequence(numberedItems: IReadOnlyList<_>) =
-    let maxPosition = numberedItems |> Seq.map fst |> Seq.max
+    let maxPosition =
+        if numberedItems.Count = 0 then 0
+        else numberedItems |> Seq.map fst |> Seq.max
     let itemsByPosition = Map.ofSeq numberedItems
     { new IPositionedSequence<_> with
         member _.AllowedToInsertAtArbitraryPlaces = false
@@ -173,10 +175,8 @@ let ``Constrained decyphered backtrace test 0``(): unit =
         4, 'B'
         5, 'D'
     |] "ABCD" [|
-        4, 4
-        4, 3
+        5, 4
         3, 3
-        0, 0
     |]
 
 let private doDiffAndAssert initial target (initialString: string) allowedToInsert =
@@ -255,6 +255,13 @@ let ``Constrained diff test 4``(): unit =
         2, 'C'
         3, 'B'
         4, 'D'
+    |] "ABCDE"
+
+[<Fact>]
+let ``Constrained diff test 5``(): unit =
+    doConstrainedDiffTest [|
+        3, 'B'
+        5, 'D'
     |] "ABCDE"
 
 

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -1,5 +1,8 @@
 module Praefectus.Tests.Core.DiffTests
 
+open System
+
+open System.Collections.Generic
 open Xunit
 
 open Praefectus.Core.Diff
@@ -20,7 +23,7 @@ let applyInstructions (instructions: EditInstruction<'a> seq) (sequence: 'a seq)
     }
 
 let private doSesLengthTest initial required expectedLength =
-    let actualSesLength = shortestEditScriptLength (Seq.toArray initial) (Seq.toArray required)
+    let actualSesLength, _, _ = shortestEditScriptTrace (Seq.toArray initial) (Seq.toArray required)
     Assert.Equal(expectedLength, actualSesLength)
 
 [<Fact>]
@@ -31,18 +34,80 @@ let ``Shortest edit script test 2``(): unit = doSesLengthTest "" "a" 1
 let ``Shortest edit script test 3``(): unit = doSesLengthTest "a" "" 1
 [<Fact>]
 let ``Shortest edit script test 4``(): unit = doSesLengthTest "abc" "b" 2
+[<Fact>]
+let ``Shortest edit script test 5``(): unit = doSesLengthTest "abcabc" "abc" 3
+
+let private convertHistory a b array2d =
+    let max = Array.length a + Array.length b
+    array2d
+    |> Array.map (fun sampleArray ->
+        let realArray = Array.CreateInstance(typeof<int>, [| max * 2 + 1 |], [| -max |])
+        let offset = 1 - Array.length sampleArray
+        sampleArray |> Array.iteri (fun i x ->
+            if x <> -1 then
+                realArray.SetValue(x, i * 2 + offset)
+        )
+        realArray
+    )
+
+let private assertHistoryEqual (expected: Array[]) (actual: IReadOnlyList<Array>) =
+    Assert.Equal(expected.Length, actual.Count)
+
+    Seq.zip expected actual |> Seq.iteri (fun i (expectedStep, actualStep) ->
+        let lower = expectedStep.GetLowerBound 0
+        let upper = expectedStep.GetUpperBound 0
+        let length = expectedStep.GetLength 0
+        Assert.Equal(lower, actualStep.GetLowerBound 0)
+        Assert.Equal(upper, actualStep.GetUpperBound 0)
+        Assert.Equal(length, actualStep.GetLength 0)
+
+        for k in lower..upper do
+            let expectedItem = expectedStep.GetValue k :?> int
+            let actualItem = actualStep.GetValue k :?> int
+            if expectedItem <> actualItem then
+                let expectedString = String.Join("; ", Seq.cast<int> expectedStep)
+                let actualString = String.Join("; ", Seq.cast<int> actualStep)
+                let message = $"Historical arrays aren't equal at step {i}.\nExpected: [{expectedString}],\nactual:   [{actualString}]"
+                Assert.True(false, message)
+    )
+
+
+[<Fact>]
+let ``Trace array test from the paper``(): unit =
+    let seqA = Seq.toArray "ABCABBA"
+    let seqB = Seq.toArray "CBABAC"
+    let sesLength, history, k = shortestEditScriptTrace seqA seqB
+
+    let expectedHistory = convertHistory seqA seqB [|
+        //          0 1 2 3 4
+        [|          0         |]
+        [|        0 ; 1       |]
+        [|      2 ; 2 ; 3     |]
+        [|    3 ; 4 ; 5 ; 5   |]
+        [| -1 ; 4 ; 5 ; 7 ; 7 |]
+        [|        5 ; 7       |]
+    |]
+
+    Assert.Equal(sesLength, 5)
+    Assert.Equal(k, 1)
+    assertHistoryEqual expectedHistory history
 
 let private doDiffTest initial required =
-    let instructions = diff initial required
+    let instructions = diff (Seq.toArray initial) (Seq.toArray required)
     let result = applyInstructions instructions initial
     Assert.Equal<'a>(initial, result)
 
 [<Fact>]
-let ``Diff algorithm works on simple cases``(): unit =
-    doDiffTest "" ""
-    doDiffTest "abcabc" "abc"
-    doDiffTest "abcabc" ""
-    doDiffTest "" "abcabc"
-    doDiffTest "abcdef" "ade"
-    doDiffTest "abcdef" "fedcba"
-    doDiffTest "abcdef" "afedcbabcd"
+let ``Diff test 1``(): unit = doDiffTest "" ""
+[<Fact>]
+let ``Diff test 2``(): unit = doDiffTest "abcabc" "abc"
+[<Fact>]
+let ``Diff test 3``(): unit = doDiffTest "abcabc" ""
+[<Fact>]
+let ``Diff test 4``(): unit = doDiffTest "" "abcabc"
+[<Fact>]
+let ``Diff test 5``(): unit = doDiffTest "abcdef" "ade"
+[<Fact>]
+let ``Diff test 6``(): unit = doDiffTest "abcdef" "fedcba"
+[<Fact>]
+let ``Diff test 7``(): unit = doDiffTest "abcdef" "afedcbabcd"

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -169,3 +169,7 @@ let ``Diff instruction test 1``(): unit =
         LeaveItem
         LeaveItem
     |]
+
+[<Fact>]
+let ``Constrained diff algorithm tests``(): unit =
+    Assert.True false

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -25,9 +25,9 @@ let applyInstructions (instructions: EditInstruction<'a> seq) (sequence: 'a seq)
 let private toSimplePositionedSequence items =
     let itemArray = Seq.toArray items
     { new IPositionedSequence<_> with
-        member _.MaxPosition = itemArray.Length + 1
-        member _.AcceptsOn(position, item) =
-            itemArray.[position - 1] = item
+        member _.MaxPosition = itemArray.Length
+        member _.AcceptsOn(index, item) =
+            itemArray.[index] = item
     }
 
 let private doSesLengthTest initial required expectedLength =
@@ -53,7 +53,8 @@ let private createPositionedSequence(numberedItems: IReadOnlyList<_>) =
     let itemsByPosition = Map.ofSeq numberedItems
     { new IPositionedSequence<_> with
         member _.MaxPosition = maxPosition
-        member _.AcceptsOn(position, item) =
+        member _.AcceptsOn(index, item) =
+            let position = index + 1
             match Map.tryFind position itemsByPosition with
             | None -> true
             | Some existingItem when existingItem = item -> true

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -6,6 +6,7 @@ open System.Collections.Generic
 open Xunit
 
 open Praefectus.Core.Diff
+open Praefectus.Core.Diff.Algorithms
 
 let applyInstructions (instructions: EditInstruction<'a> seq) (sequence: 'a seq): 'a seq =
     seq {
@@ -233,7 +234,7 @@ let ``Constrained decyphered backtrace test 2``(): unit =
     |]
 
 let private doDiffAndAssert initial target (initialString: string) allowedToInsert =
-    let instructions = diff initial (Seq.toArray target) |> Seq.cache
+    let instructions = myersGeneralized initial (Seq.toArray target) |> Seq.cache
     let result = applyInstructions instructions initialString |> Seq.toArray |> String
     Assert.Equal(target, result)
     instructions

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -1,0 +1,34 @@
+module Praefectus.Tests.Core.DiffTests
+
+open Xunit
+
+open Praefectus.Core.Diff
+
+let applyInstructions (instructions: EditInstruction<'a> seq) (sequence: 'a seq): 'a seq =
+    seq {
+        use sequenceEnumerator = sequence.GetEnumerator()
+        use instructionEnumerator = instructions.GetEnumerator()
+
+        while instructionEnumerator.MoveNext() do
+            let command = instructionEnumerator.Current
+            match command with
+            | DeleteItem -> sequenceEnumerator.MoveNext() |> ignore
+            | InsertItem x -> yield x
+            | LeaveItem ->
+                sequenceEnumerator.MoveNext() |> ignore
+                yield sequenceEnumerator.Current
+    }
+
+let private doDiffTest initial required =
+    let instructions = diff initial required
+    let result = applyInstructions instructions initial
+    Assert.Equal<'a>(initial, result)
+
+[<Fact>]
+let ``Diff algorithm works on simple cases``(): unit =
+    doDiffTest "abcabc" "abc"
+    doDiffTest "abcabc" ""
+    doDiffTest "" "abcabc"
+    doDiffTest "abcdef" "ade"
+    doDiffTest "abcdef" "fedcba"
+    doDiffTest "abcdef" "afedcbabcd"

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -19,6 +19,19 @@ let applyInstructions (instructions: EditInstruction<'a> seq) (sequence: 'a seq)
                 yield sequenceEnumerator.Current
     }
 
+let private doSesLengthTest initial required expectedLength =
+    let actualSesLength = shortestEditScriptLength (Seq.toArray initial) (Seq.toArray required)
+    Assert.Equal(expectedLength, actualSesLength)
+
+[<Fact>]
+let ``Shortest edit script test 1``(): unit = doSesLengthTest "" "" 0
+[<Fact>]
+let ``Shortest edit script test 2``(): unit = doSesLengthTest "" "a" 1
+[<Fact>]
+let ``Shortest edit script test 3``(): unit = doSesLengthTest "a" "" 1
+[<Fact>]
+let ``Shortest edit script test 4``(): unit = doSesLengthTest "abc" "b" 2
+
 let private doDiffTest initial required =
     let instructions = diff initial required
     let result = applyInstructions instructions initial
@@ -26,6 +39,7 @@ let private doDiffTest initial required =
 
 [<Fact>]
 let ``Diff algorithm works on simple cases``(): unit =
+    doDiffTest "" ""
     doDiffTest "abcabc" "abc"
     doDiffTest "abcabc" ""
     doDiffTest "" "abcabc"

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -116,8 +116,8 @@ let ``Decyphered backtrace for diff from paper``(): unit =
 
 let private doDiffTest initial required =
     let instructions = diff (Seq.toArray initial) (Seq.toArray required)
-    let result = applyInstructions instructions initial
-    Assert.Equal<'a>(initial, result)
+    let result = applyInstructions instructions initial |> Seq.toArray |> String
+    Assert.Equal(initial, result)
 
 [<Fact>]
 let ``Diff test 0``(): unit = doDiffTest "ABCABBA" "CBABAC"

--- a/Praefectus.Tests/Core/DiffTests.fs
+++ b/Praefectus.Tests/Core/DiffTests.fs
@@ -337,6 +337,16 @@ let ``Constrained diff test 9``(): unit =
         9, 'C'
     |] "ABCDEFG"
 
+[<Fact>]
+let ``Constrained diff test 10``(): unit =
+    doConstrainedDiffTest [|
+        1, 'A'
+        3, 'D'
+        4, 'E'
+        6, 'B'
+        7, 'C'
+    |] "ABCDE"
+
 let private doDiffInstructionTest initial required (initialString: string) expectedInstructions allowedToInsert =
     let instructions = doDiffAndAssert initial required initialString allowedToInsert
     Assert.Equal<EditInstruction<_>>(expectedInstructions, instructions)
@@ -410,4 +420,23 @@ let ``Constrained diff instruction test 2``(): unit =
         LeaveItem
         DeleteItem
         DeleteItem
+    |]
+
+[<Fact>]
+let ``Constrained diff instruction test 3``(): unit =
+    doConstrainedDiffInstructionTest [|
+        1, 'A'
+        3, 'D'
+        4, 'E'
+        6, 'B'
+        7, 'C'
+    |] "ABCDE" [|
+        DeleteItem
+        DeleteItem
+        DeleteItem
+        InsertItem 'A'
+        LeaveItem
+        LeaveItem
+        InsertItem 'D'
+        InsertItem 'E'
     |]

--- a/Praefectus.Tests/Core/EditGraphTests.fs
+++ b/Praefectus.Tests/Core/EditGraphTests.fs
@@ -1,0 +1,63 @@
+﻿module Praefectus.Tests.Core.EditGraphTests
+
+open Xunit
+
+open Praefectus.Core.Diff
+open Praefectus.Tests.TestFramework.DiffUtils
+
+let doRouteStepAllTest sequenceADef sequenceB steps expectedBacktraces =
+    let sequenceA = createPositionedSequence sequenceADef
+    let graph = EditGraph(sequenceA, Seq.toArray sequenceB)
+
+    let mutable currentBacktraces = graph.InitialBacktraces()
+    for i in 1..steps do
+        currentBacktraces <- graph.StepAll currentBacktraces |> Seq.toArray
+
+    Assert.Equal<list<int * int>>(expectedBacktraces, currentBacktraces)
+
+let sequence = [|
+    2, 'A'
+    4, 'D'
+    5, 'E'
+    6, 'F'
+    7, 'G'
+    8, 'B'
+    9, 'C'
+|]
+
+[<Fact>]
+let ``EditGraph traverse test 0``() =
+    doRouteStepAllTest sequence "ABCDEFG" 0 [|
+        [1, 1; 0, 0]
+    |]
+
+[<Fact>]
+let ``EditGraph traverse test 1``() =
+    doRouteStepAllTest sequence "ABCDEFG" 1 [|
+        [      2, 1; 1, 1; 0, 0]
+        [3, 2; 2, 1; 1, 1; 0, 0]
+    |]
+
+[<Fact>]
+let ``EditGraph traverse test 2``() =
+    doRouteStepAllTest sequence "ABCDEFG" 2 [|
+        [3, 2; 2, 1; 1, 1; 0, 0]
+        [2, 2; 2, 1; 1, 1; 0, 0]
+        [7, 7; 2, 2; 2, 1; 1, 1; 0, 0]
+        [4, 2; 3, 2; 2, 1; 1, 1; 0, 0]
+    |]
+
+let doRouteOneStepTest sequenceADef sequenceB route expectedBacktraces =
+    let sequenceA = createPositionedSequence sequenceADef
+    let graph = EditGraph(sequenceA, Seq.toArray sequenceB)
+
+    let newBacktraces = graph.StepAll(Seq.singleton route) |> Seq.toArray
+    Assert.Equal<list<int * int>>(expectedBacktraces, newBacktraces)
+
+[<Fact>]
+let ``EditGraph traverse step test 0``() =
+    doRouteOneStepTest sequence "ABCDEFG" [2, 1; 1, 1; 0, 0] [|
+        [3, 2; 2, 1; 1, 1; 0, 0]
+        [2, 2; 2, 1; 1, 1; 0, 0]
+        [7, 7; 2, 2; 2, 1; 1, 1; 0, 0]
+    |]

--- a/Praefectus.Tests/Core/EditGraphTests.fs
+++ b/Praefectus.Tests/Core/EditGraphTests.fs
@@ -15,7 +15,7 @@ let doRouteStepAllTest sequenceADef sequenceB steps expectedBacktraces =
 
     Assert.Equal<list<int * int>>(expectedBacktraces, currentBacktraces)
 
-let sequence = [|
+let testSequenceDef = [|
     2, 'A'
     4, 'D'
     5, 'E'
@@ -27,21 +27,22 @@ let sequence = [|
 
 [<Fact>]
 let ``EditGraph traverse test 0``() =
-    doRouteStepAllTest sequence "ABCDEFG" 0 [|
+    doRouteStepAllTest testSequenceDef "ABCDEFG" 0 [|
         [1, 1; 0, 0]
     |]
 
 [<Fact>]
 let ``EditGraph traverse test 1``() =
-    doRouteStepAllTest sequence "ABCDEFG" 1 [|
+    doRouteStepAllTest testSequenceDef "ABCDEFG" 1 [|
         [      2, 1; 1, 1; 0, 0]
         [3, 2; 2, 1; 1, 1; 0, 0]
     |]
 
 [<Fact>]
 let ``EditGraph traverse test 2``() =
-    doRouteStepAllTest sequence "ABCDEFG" 2 [|
+    doRouteStepAllTest testSequenceDef "ABCDEFG" 2 [|
         [3, 2; 2, 1; 1, 1; 0, 0]
+        [3, 1; 2, 1; 1, 1; 0, 0]
         [2, 2; 2, 1; 1, 1; 0, 0]
         [7, 7; 2, 2; 2, 1; 1, 1; 0, 0]
         [4, 2; 3, 2; 2, 1; 1, 1; 0, 0]
@@ -55,9 +56,25 @@ let doRouteOneStepTest sequenceADef sequenceB route expectedBacktraces =
     Assert.Equal<list<int * int>>(expectedBacktraces, newBacktraces)
 
 [<Fact>]
-let ``EditGraph traverse step test 0``() =
-    doRouteOneStepTest sequence "ABCDEFG" [2, 1; 1, 1; 0, 0] [|
+let ``EditGraph traverse step test 0``(): unit =
+    doRouteOneStepTest testSequenceDef "ABCDEFG" [2, 1; 1, 1; 0, 0] [|
         [3, 2; 2, 1; 1, 1; 0, 0]
+        [3, 1; 2, 1; 1, 1; 0, 0]
         [2, 2; 2, 1; 1, 1; 0, 0]
         [7, 7; 2, 2; 2, 1; 1, 1; 0, 0]
+    |]
+
+[<Fact>]
+let ``EditGraph traverse step test 1``(): unit =
+    doRouteOneStepTest [|
+        1, 'A'
+        3, 'D'
+        4, 'E'
+        6, 'B'
+        7, 'C'
+    |] "ABCDE" [1, 0; 0, 0] [|
+        [2, 1; 1, 0; 0, 0]
+        [2, 0; 1, 0; 0, 0]
+        [1, 1; 1, 0; 0, 0]
+        [2, 2; 1, 1; 1, 0; 0, 0]
     |]

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -1,12 +1,15 @@
 module Praefectus.Tests.Core.OrderingTests
 
+open System
+
 open Xunit
 
 open Praefectus.Core
 open Praefectus.Storage
 
-let private generateTasksByName = Seq.map (fun name ->
-    { Task.Empty<_> { FileSystemStorage.FileName = sprintf "%s.md" name } with
+let private generateTasksByName = Seq.mapi (fun i name ->
+    { Task.Empty<_> { FileSystemStorage.FileName = sprintf "%d.%s.md" i name } with
+        Order = Some i
         Name = Some name }
 )
 
@@ -46,6 +49,58 @@ let ``reorder should move unordered items to the end``(): unit =
     let reordered = Ordering.reorder predicates tasks
     let lastTask = Seq.last reordered
     Assert.Equal(Some "ca", lastTask.Name)
+
+[<Fact>]
+let ``applyOrderInStorage should do nothing if order is already right``(): unit =
+    let tasks = generateTasksByName [| "a"; "b"; "c"; "d"; "e"; "f" |]
+    let instructions = Ordering.applyOrderInStorage tasks
+    Assert.Equal(Array.empty, instructions)
+
+[<Fact>]
+let ``applyOrderInStorage order test case 1``(): unit =
+    let tasks = generateTasksByName [| "b"; "c"; "d"; "a" |] |> Seq.cache
+    let a = Seq.last tasks
+    let reorderedTasks = seq {
+        a
+        yield! Seq.take 4 tasks
+    }
+
+    let instructions = Ordering.applyOrderInStorage reorderedTasks |> Seq.toArray
+    Assert.Equal(4, instructions.Length)
+
+    let isTask fileName =
+        let attributes = FileSystemStorage.readFsAttributes fileName
+        Action<_>(fun (instruction: StorageInstruction<FileSystemStorage.FileSystemTaskState>) ->
+            Assert.Equal(attributes.Name, instruction.Task.Name)
+            Assert.Equal(fileName, instruction.NewState.FileName)
+        )
+
+    Assert.Collection(instructions,
+                      isTask "1.a.md",
+                      isTask "2.b.md",
+                      isTask "3.c.md",
+                      isTask "4.d.md")
+
+[<Fact>]
+let ``applyOrderInStorage order test case 2``(): unit =
+    // TODO: Test case for:
+    //   1.a.md ; 2.c.md ; 3.b.md ; 4.d.md
+    // → 1.a.md ; 2.b.md ; 3.c.md ; 4.d.md
+    Assert.True false
+
+[<Fact>]
+let ``applyOrderInStorage order test case 3``(): unit =
+    // TODO: Test case for:
+    //   1.a.md ; 2.b.md ; 3.b.md ; 4.d.md (switch order for two files named *.b.md)
+    // → 1.a.md ; 3.b.md ; 4.b.md ; 5.d.md
+    Assert.True false
+
+[<Fact>]
+let ``applyOrderInStorage order test case 4``(): unit =
+    // TODO: Test case for:
+    //   1.a.md ; 3.c.md ; 4.b.md ; 5.d.md
+    // → 1.a.md ; 2.b.md ; 3.c.md ; 5.d.md
+    Assert.True false
 
 [<Fact>]
 let ``applyOrderInStorage should rename minimal amount of items``(): unit =

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -7,10 +7,11 @@ open Xunit
 open Praefectus.Core
 open Praefectus.Storage
 
-let private generateTasksByName = Array.mapi (fun i name ->
-    { Task.Empty<_> { FileSystemStorage.FileName = sprintf "%d.%s.md" i name } with
-        Order = Some i
-        Name = Some name }
+let private generateTasksByName = Array.mapi (fun i id ->
+    let order = i + 1
+    { Task.Empty<_> { FileSystemStorage.FileName = sprintf "%d.%s.md" order id } with
+        Order = Some order
+        Id = Some id }
 )
 
 [<Fact>]
@@ -62,7 +63,7 @@ let ``applyOrderInStorage order test case 1``(): unit =
     let a = Seq.last tasks
     let reorderedTasks = [|
         a
-        yield! Seq.take 4 tasks
+        yield! Seq.take 3 tasks
     |]
 
     let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState reorderedTasks |> Seq.toArray
@@ -71,7 +72,7 @@ let ``applyOrderInStorage order test case 1``(): unit =
     let isTask fileName =
         let attributes = FileSystemStorage.readFsAttributes fileName
         Action<_>(fun (instruction: StorageInstruction<FileSystemStorage.FileSystemTaskState>) ->
-            Assert.Equal(attributes.Name, instruction.Task.Name)
+            Assert.Equal(attributes.Id, instruction.Task.Id)
             Assert.Equal(fileName, instruction.NewState.FileName)
         )
 

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -179,3 +179,7 @@ let ``applyOrderInStorage should rename minimal amount of items``(): unit =
         Assert.Equal(tasks.[0], i.Task)
         Assert.Equal("3.a.md", i.NewState.FileName)
     )
+
+[<Fact>]
+let ``applyOrderInStorage should work for duplicated orders``(): unit =
+    Assert.True false

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -7,7 +7,7 @@ open Xunit
 open Praefectus.Core
 open Praefectus.Storage
 
-let private generateTasksByName = Array.mapi (fun i id ->
+let private generateTasksById = Array.mapi (fun i id ->
     let order = i + 1
     { Task.Empty<_> { FileSystemStorage.FileName = sprintf "%d.%s.md" order id } with
         Order = Some order
@@ -22,44 +22,44 @@ let private generateTaskByAttributes fileName (attributes: FileSystemStorage.FsA
 
 [<Fact>]
 let ``Ordering should be stable``(): unit =
-    let tasks = generateTasksByName [| "b"; "ab"; "aa" |]
+    let tasks = generateTasksById [| "b"; "ab"; "aa" |]
     let predicates = [|
-        fun task -> task.Name.Value.[0] = 'a'
+        fun task -> task.Id.Value.[0] = 'a'
     |]
     let reordered = Ordering.reorder predicates tasks
     Assert.Collection(
         reordered,
-        (fun t -> Assert.Equal("ab", t.Name.Value)),
-        (fun t -> Assert.Equal("aa", t.Name.Value)),
-        fun t -> Assert.Equal("b", t.Name.Value)
+        (fun t -> Assert.Equal("ab", t.Id.Value)),
+        (fun t -> Assert.Equal("aa", t.Id.Value)),
+        fun t -> Assert.Equal("b", t.Id.Value)
     )
 
 [<Fact>]
 let ``reorder should order items``(): unit =
-    let tasks = generateTasksByName [| "aa"; "ca"; "ab"; "ba" |]
+    let tasks = generateTasksById [| "aa"; "ca"; "ab"; "ba" |]
     let predicates = [|
-        fun task -> task.Name.Value.[0] = 'a'
-        fun task -> task.Name.Value.[0] = 'b'
-        fun task -> task.Name.Value.[0] = 'c'
+        fun task -> task.Id.Value.[0] = 'a'
+        fun task -> task.Id.Value.[0] = 'b'
+        fun task -> task.Id.Value.[0] = 'c'
     |]
     let reordered = Ordering.reorder predicates tasks
-    let sorted = tasks |> Seq.sortBy (fun t -> t.Name)
+    let sorted = tasks |> Seq.sortBy (fun t -> t.Id)
     Assert.Equal<Task<_>>(sorted, reordered)
 
 [<Fact>]
 let ``reorder should move unordered items to the end``(): unit =
-    let tasks = generateTasksByName [| "aa"; "ca"; "ab"; "ba" |]
+    let tasks = generateTasksById [| "aa"; "ca"; "ab"; "ba" |]
     let predicates = [|
-        fun task -> task.Name.Value.[0] = 'a'
-        fun task -> task.Name.Value.[0] = 'b'
+        fun task -> task.Id.Value.[0] = 'a'
+        fun task -> task.Id.Value.[0] = 'b'
     |]
     let reordered = Ordering.reorder predicates tasks
     let lastTask = Seq.last reordered
-    Assert.Equal(Some "ca", lastTask.Name)
+    Assert.Equal(Some "ca", lastTask.Id)
 
 [<Fact>]
 let ``applyOrderInStorage should do nothing if order is already right``(): unit =
-    let tasks = generateTasksByName [| "a"; "b"; "c"; "d"; "e"; "f" |]
+    let tasks = generateTasksById [| "a"; "b"; "c"; "d"; "e"; "f" |]
     let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState tasks
     Assert.Equal(Array.empty, instructions)
 
@@ -138,8 +138,8 @@ let ``applyOrderInStorage order test case 4``(): unit =
 
 [<Fact>]
 let ``applyOrderInStorage order test case 5``(): unit =
-    testTaskOrdering [| "1.a.md"; "3.d.md"; "4.e.md"; "6.b.md"; "7.c.md" |]
-                     [| "1.a.md"; "2.b.md"; "3.c.md"; "4.d.md"; "5.e.md" |]
+    testTaskOrdering [| "1.a.md";           "3.d.md"; "4.e.md";           "6.b.md"; "7.c.md" |]
+                     [| "1.a.md";                                         "6.b.md"; "7.c.md"; "8.d.md"; "9.e.md" |]
 
 [<Fact>]
 let ``applyOrderInStorage order test case 6``(): unit =
@@ -148,38 +148,6 @@ let ``applyOrderInStorage order test case 6``(): unit =
 
 [<Fact>]
 let ``applyOrderInStorage order test case 7``(): unit =
-    testTaskOrdering [| "2.a.md"; "3.d.md"; "4.e.md"; "5.f.md"; "6.g.md"; "7.b.md"; "8.c.md" |]
-                     [| "2.a.md"; "3.b.md"; "4.c.md"; "5.d.md"; "6.e.md"; "7.f.md"; "8.g.md" |]
-
-[<Fact>]
-let ``applyOrderInStorage order test case with same name``(): unit =
-    // 1.a.md ; 2.b.md ; 3.b.md ; 4.d.md
-    // -> 1.a.md ; 3.b.md ; 4.b.md ; 5.d.md (change order of 2.b.md and 3.b.md)
-    let tasks = generateTasksByName [| "a"; "b"; "b"; "d" |]
-    let reorderedTasks = [|
-        tasks.[0]
-        tasks.[2]
-        tasks.[1]
-        tasks.[3]
-    |]
-
-    let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState reorderedTasks
-
-    Assert.Collection(instructions,
-                      isTask "4.b.md" (fun instruction ->
-                          Assert.Equal("2.b.md", instruction.Task.StorageState.FileName)
-                      ),
-                      isTask "5.d.md" ignore)
-
-[<Fact>]
-let ``applyOrderInStorage should rename minimal amount of items``(): unit =
-    let tasks = generateTasksByName [| "a"; "a" |] |> Seq.rev |> Seq.toArray
-    let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState tasks
-    Assert.Collection(instructions, fun i ->
-        Assert.Equal(tasks.[0], i.Task)
-        Assert.Equal("3.a.md", i.NewState.FileName)
-    )
-
-[<Fact>]
-let ``applyOrderInStorage should work for duplicated orders``(): unit =
-    Assert.True false
+    testTaskOrdering
+     <| [| "2.a.md"; "3.d.md"; "4.e.md"; "5.f.md"; "6.g.md"; "7.b.md"; "8.c.md" |]
+     <| [| "2.a.md";                                         "7.b.md"; "8.c.md"; "9.d.md"; "10.e.md"; "11.f.md"; "12.g.md" |]

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -124,7 +124,7 @@ let ``applyOrderInStorage order test case 1``(): unit =
 [<Fact>]
 let ``applyOrderInStorage order test case 2``(): unit =
     testTaskOrdering [| "1.a.md"; "2.c.md"; "3.b.md"; "4.d.md" |]
-                     [| "1.a.md"; "2.b.md"; "3.c.md"; "4.d.md" |]
+                     [| "1.a.md"; "3.b.md"; "4.c.md"; "5.d.md" |]
 
 [<Fact>]
 let ``applyOrderInStorage order test case 3``(): unit =

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -72,16 +72,16 @@ let private isTask fileName additionalChecks =
     )
 
 let private generateRenameRequirements initialFileNames requiredFileNames =
-    let fileNamesByTaskName =
+    let fileNamesByTaskId =
         initialFileNames
         |> Seq.map FileSystemStorage.readFsAttributes
-        |> Seq.map(fun ({ Name = name } as attrs) -> name, attrs)
+        |> Seq.map(fun ({ Id = id } as attrs) -> id, attrs)
         |> Map.ofSeq
 
     requiredFileNames
     |> Seq.choose(fun fileName ->
         let attrs = FileSystemStorage.readFsAttributes fileName
-        let oldAttrs = fileNamesByTaskName.[attrs.Name]
+        let oldAttrs = fileNamesByTaskId.[attrs.Id]
         if oldAttrs.Order <> attrs.Order then
             Some(isTask fileName ignore)
         else
@@ -96,14 +96,14 @@ let private testTaskOrdering initialFileNames orderedFileNames =
             let attributes = FileSystemStorage.readFsAttributes fileName
             generateTaskByAttributes fileName attributes
         )
-    let tasksByNameMap =
+    let tasksByIdMap =
         tasks
-        |> Seq.map (fun t -> t.Name, t)
+        |> Seq.map (fun t -> t.Id, t)
         |> Map.ofSeq
     let requiredOrder =
         orderedFileNames
         |> Seq.map FileSystemStorage.readFsAttributes
-        |> Seq.map (fun { Name = name } -> tasksByNameMap.[name])
+        |> Seq.map (fun { Id = id } -> tasksByIdMap.[id])
         |> Seq.toArray
 
     let instructions = Ordering.applyOrderInStorage FileSystemStorage.getNewState requiredOrder

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -93,7 +93,7 @@ let private testTaskOrdering initialFileNames orderedFileNames =
     let tasks =
         initialFileNames
         |> Seq.map (fun fileName ->
-            let attributes =  FileSystemStorage.readFsAttributes fileName
+            let attributes = FileSystemStorage.readFsAttributes fileName
             generateTaskByAttributes fileName attributes
         )
     let tasksByNameMap =
@@ -119,7 +119,7 @@ let ``applyOrderInStorage order test case 0``(): unit =
 [<Fact>]
 let ``applyOrderInStorage order test case 1``(): unit =
     testTaskOrdering [| "1.b.md"; "2.c.md"; "3.d.md"; "4.a.md" |]
-                     [| "1.a.md"; "2.b.md"; "3.c.md"; "4.d.md" |]
+                     [| "4.a.md"; "5.b.md"; "6.c.md"; "7.d.md" |]
 
 [<Fact>]
 let ``applyOrderInStorage order test case 2``(): unit =
@@ -133,17 +133,17 @@ let ``applyOrderInStorage order test case 3``(): unit =
 
 [<Fact>]
 let ``applyOrderInStorage order test case 4``(): unit =
-    testTaskOrdering [| "1.a.md"; "4.d.md"; "5.e.md"; "6.b.md"; "7.c.md" |]
-                     [| "1.a.md"; "2.b.md"; "3.c.md"; "5.d.md"; "6.e.md" |]
+    testTaskOrdering [| "1.a.md";                     "4.d.md"; "5.e.md"; "6.b.md"; "7.c.md" |]
+                     [| "1.a.md"; "2.b.md"; "3.c.md"; "4.d.md"; "5.e.md" |]
 
 [<Fact>]
 let ``applyOrderInStorage order test case 5``(): unit =
     testTaskOrdering [| "1.a.md"; "3.d.md"; "4.e.md"; "6.b.md"; "7.c.md" |]
-                     [| "1.a.md"; "2.b.md"; "3.c.md"; "5.d.md"; "6.e.md" |]
+                     [| "1.a.md"; "2.b.md"; "3.c.md"; "4.d.md"; "5.e.md" |]
 
 [<Fact>]
 let ``applyOrderInStorage order test case 6``(): unit =
-    testTaskOrdering [| "2.a.md"; "4.d.md"; "5.e.md"; "6.f.md"; "7.g.md"; "8.b.md"; "9.c.md" |]
+    testTaskOrdering [|           "2.a.md";           "4.d.md"; "5.e.md"; "6.f.md"; "7.g.md"; "8.b.md"; "9.c.md" |]
                      [| "1.a.md"; "2.b.md"; "3.c.md"; "4.d.md"; "5.e.md"; "6.f.md"; "7.g.md" |]
 
 [<Fact>]

--- a/Praefectus.Tests/Core/OrderingTests.fs
+++ b/Praefectus.Tests/Core/OrderingTests.fs
@@ -1,0 +1,57 @@
+module Praefectus.Tests.Core.OrderingTests
+
+open Xunit
+
+open Praefectus.Core
+open Praefectus.Storage
+
+let private generateTasksByName = Seq.map (fun name ->
+    { Task.Empty<_> { FileSystemStorage.FileName = sprintf "%s.md" name } with
+        Name = Some name }
+)
+
+[<Fact>]
+let ``Ordering should be stable``(): unit =
+    let tasks = generateTasksByName [| "b"; "ab"; "aa" |]
+    let predicates = [|
+        fun task -> task.Name.Value.[0] = 'a'
+    |]
+    let reordered = Ordering.reorder predicates tasks
+    Assert.Collection(
+        reordered,
+        (fun t -> Assert.Equal("ab", t.Name.Value)),
+        (fun t -> Assert.Equal("aa", t.Name.Value)),
+        fun t -> Assert.Equal("b", t.Name.Value)
+    )
+
+[<Fact>]
+let ``reorder should order items``(): unit =
+    let tasks = generateTasksByName [| "aa"; "ca"; "ab"; "ba" |]
+    let predicates = [|
+        fun task -> task.Name.Value.[0] = 'a'
+        fun task -> task.Name.Value.[0] = 'b'
+        fun task -> task.Name.Value.[0] = 'c'
+    |]
+    let reordered = Ordering.reorder predicates tasks
+    let sorted = tasks |> Seq.sortBy (fun t -> t.Name)
+    Assert.Equal<Task<_>>(sorted, reordered)
+
+[<Fact>]
+let ``reorder should move unordered items to the end``(): unit =
+    let tasks = generateTasksByName [| "aa"; "ca"; "ab"; "ba" |]
+    let predicates = [|
+        fun task -> task.Name.Value.[0] = 'a'
+        fun task -> task.Name.Value.[0] = 'b'
+    |]
+    let reordered = Ordering.reorder predicates tasks
+    let lastTask = Seq.last reordered
+    Assert.Equal(Some "ca", lastTask.Name)
+
+[<Fact>]
+let ``applyOrderInStorage should rename minimal amount of items``(): unit =
+    let tasks = generateTasksByName [| "a"; "a" |] |> Seq.rev |> Seq.toArray
+    let instructions = Ordering.applyOrderInStorage tasks
+    Assert.Collection(instructions, fun i ->
+        Assert.Equal(tasks.[0], i.Task)
+        Assert.Equal("3.a.md", i.NewState.FileName)
+    )

--- a/Praefectus.Tests/Praefectus.Tests.fsproj
+++ b/Praefectus.Tests/Praefectus.Tests.fsproj
@@ -11,7 +11,7 @@
         <Compile Include="TestFramework\DiffUtils.fs" />
         <Compile Include="Console\EntryPointTests.fs" />
         <Compile Include="Console\DatabaseTests.fs" />
-        <Compile Include="Console\SortCommandTests.fs" />
+        <Compile Include="Console\OrderCommandTests.fs" />
         <Compile Include="Core\OrderingTests.fs" />
         <Compile Include="Core\EditGraphTests.fs" />
         <Compile Include="Core\DiffTests.fs" />

--- a/Praefectus.Tests/Praefectus.Tests.fsproj
+++ b/Praefectus.Tests/Praefectus.Tests.fsproj
@@ -12,6 +12,7 @@
         <Compile Include="Console\DatabaseTests.fs" />
         <Compile Include="Console\SortCommandTests.fs" />
         <Compile Include="Core\OrderingTests.fs" />
+        <Compile Include="Core\DiffTests.fs" />
         <Compile Include="Storage\JsonTests.fs" />
         <Compile Include="Storage\MarkdownDirectoryTests.fs" />
         <Compile Include="Storage\FileSystemStorageTests.fs" />

--- a/Praefectus.Tests/Praefectus.Tests.fsproj
+++ b/Praefectus.Tests/Praefectus.Tests.fsproj
@@ -6,11 +6,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Console\ConsoleTestUtils.fs" />
+        <Compile Include="TestFramework\ConsoleTestUtils.fs" />
+        <Compile Include="TestFramework\DatabaseUtils.fs" />
         <Compile Include="Console\EntryPointTests.fs" />
         <Compile Include="Console\DatabaseTests.fs" />
+        <Compile Include="Console\SortCommandTests.fs" />
+        <Compile Include="Core\OrderingTests.fs" />
         <Compile Include="Storage\JsonTests.fs" />
         <Compile Include="Storage\MarkdownDirectoryTests.fs" />
+        <Compile Include="Storage\FileSystemStorageTests.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Praefectus.Tests/Praefectus.Tests.fsproj
+++ b/Praefectus.Tests/Praefectus.Tests.fsproj
@@ -8,10 +8,12 @@
     <ItemGroup>
         <Compile Include="TestFramework\ConsoleTestUtils.fs" />
         <Compile Include="TestFramework\DatabaseUtils.fs" />
+        <Compile Include="TestFramework\DiffUtils.fs" />
         <Compile Include="Console\EntryPointTests.fs" />
         <Compile Include="Console\DatabaseTests.fs" />
         <Compile Include="Console\SortCommandTests.fs" />
         <Compile Include="Core\OrderingTests.fs" />
+        <Compile Include="Core\EditGraphTests.fs" />
         <Compile Include="Core\DiffTests.fs" />
         <Compile Include="Storage\JsonTests.fs" />
         <Compile Include="Storage\MarkdownDirectoryTests.fs" />

--- a/Praefectus.Tests/Storage/FileSystemStorageTests.fs
+++ b/Praefectus.Tests/Storage/FileSystemStorageTests.fs
@@ -1,0 +1,37 @@
+module Praefectus.Tests.Storage.FileSystemStorageTests
+
+open Xunit
+
+open Praefectus.Storage.FileSystemStorage
+
+[<Fact>]
+let ``Empty file name should be treated as empty name``(): unit =
+    Assert.Equal({ Order = None; Id = None; Name = Some "" }, readFsAttributes(".md"))
+
+[<Fact>]
+let ``File name with dot should be treated as empty id and name``(): unit =
+    Assert.Equal({ Order = None; Id = Some ""; Name = Some "" }, readFsAttributes("..md"))
+
+[<Fact>]
+let ``Integer order should be detected``(): unit =
+    Assert.Equal({ Order = Some 300; Id = None; Name = Some "name" }, readFsAttributes("300.name.md"))
+
+[<Fact>]
+let ``Non-integer first section should be skipped``(): unit =
+    Assert.Equal({ Order = None; Id = Some "id"; Name = Some "test" }, readFsAttributes("id.test.md"))
+
+[<Fact>]
+let ``Order only test``(): unit =
+    Assert.Equal({ Order = Some 1; Id = None; Name = None }, readFsAttributes("1.md"))
+
+[<Fact>]
+let ``Name only test``(): unit =
+    Assert.Equal({ Order = None; Id = None; Name = Some "name" }, readFsAttributes("name.md"))
+
+[<Fact>]
+let ``Full id test``(): unit =
+    Assert.Equal({ Order = Some 1; Id = Some "id"; Name = Some "name" }, readFsAttributes("1.id.name.md"))
+
+[<Fact>]
+let ``Name concatenation``(): unit =
+    Assert.Equal({ Order = Some 1; Id = Some "id"; Name = Some "name.test.1" }, readFsAttributes("1.id.name.test.1.md"))

--- a/Praefectus.Tests/Storage/FileSystemStorageTests.fs
+++ b/Praefectus.Tests/Storage/FileSystemStorageTests.fs
@@ -33,5 +33,9 @@ let ``Full id test``(): unit =
     Assert.Equal({ Order = Some 1; Id = Some "id"; Name = Some "name" }, readFsAttributes("1.id.name.md"))
 
 [<Fact>]
+let ``Only id``(): unit =
+    Assert.Equal({ Order = Some 1; Id = Some "id"; Name = Some "" }, readFsAttributes("1.id..md"))
+
+[<Fact>]
 let ``Name concatenation``(): unit =
     Assert.Equal({ Order = Some 1; Id = Some "id"; Name = Some "name.test.1" }, readFsAttributes("1.id.name.test.1.md"))

--- a/Praefectus.Tests/Storage/FileSystemStorageTests.fs
+++ b/Praefectus.Tests/Storage/FileSystemStorageTests.fs
@@ -6,7 +6,7 @@ open Praefectus.Storage.FileSystemStorage
 
 [<Fact>]
 let ``Empty file name should be treated as empty name``(): unit =
-    Assert.Equal({ Order = None; Id = None; Name = Some "" }, readFsAttributes(".md"))
+    Assert.Equal({ Order = None; Id = Some ""; Name = None }, readFsAttributes(".md"))
 
 [<Fact>]
 let ``File name with dot should be treated as empty id and name``(): unit =
@@ -14,7 +14,7 @@ let ``File name with dot should be treated as empty id and name``(): unit =
 
 [<Fact>]
 let ``Integer order should be detected``(): unit =
-    Assert.Equal({ Order = Some 300; Id = None; Name = Some "name" }, readFsAttributes("300.name.md"))
+    Assert.Equal({ Order = Some 300; Id = Some ""; Name = Some "name" }, readFsAttributes("300..name.md"))
 
 [<Fact>]
 let ``Non-integer first section should be skipped``(): unit =
@@ -25,8 +25,12 @@ let ``Order only test``(): unit =
     Assert.Equal({ Order = Some 1; Id = None; Name = None }, readFsAttributes("1.md"))
 
 [<Fact>]
-let ``Name only test``(): unit =
-    Assert.Equal({ Order = None; Id = None; Name = Some "name" }, readFsAttributes("name.md"))
+let ``Id only test``(): unit =
+    Assert.Equal({ Order = None; Id = Some "id"; Name = None }, readFsAttributes("id.md"))
+
+[<Fact>]
+let ``Test without name``(): unit =
+    Assert.Equal({ Order = Some 1; Id = Some "id"; Name = None }, readFsAttributes("1.id.md"))
 
 [<Fact>]
 let ``Full id test``(): unit =

--- a/Praefectus.Tests/Storage/JsonTests.fs
+++ b/Praefectus.Tests/Storage/JsonTests.fs
@@ -5,6 +5,7 @@ open System.Text
 
 open FSharp.Control.Tasks
 open Newtonsoft.Json
+open Praefectus.Storage.FileSystemStorage
 open Quibble.Xunit
 open Xunit
 
@@ -19,19 +20,18 @@ let private createTask id title = {
     Name = None
     Description = None
     DependsOn = Array.empty
+    StorageState = ()
 }
 
 let private testDatabase =
-    { Database.defaultDatabase with
-        Tasks = [|
-            createTask "Task1" "Perform tests"
-        |]
-    }
+    { Tasks = [|
+        createTask "Task1" "Perform tests"
+    |] }
 
-let private loadDatabase(source: Stream): System.Threading.Tasks.Task<Database> = task {
+let private loadDatabase(source: Stream): System.Threading.Tasks.Task<Database<FileSystemTaskState>> = task {
     use reader = new StreamReader(source)
     let serializer = JsonSerializer()
-    return serializer.Deserialize(reader, typeof<Database>) :?> Database
+    return serializer.Deserialize(reader, typeof<Database<FileSystemTaskState>>) :?> Database<FileSystemTaskState>
 }
 
 [<Fact>]

--- a/Praefectus.Tests/Storage/MarkdownDirectoryTests.fs
+++ b/Praefectus.Tests/Storage/MarkdownDirectoryTests.fs
@@ -37,7 +37,7 @@ let private saveTestDatabase() =
 module ReadTaskTests =
     let private doTest expectedTask (fileContent: string) = Async.RunSynchronously <| async {
         use stream = new MemoryStream(Encoding.UTF8.GetBytes fileContent)
-        let! task = MarkdownDirectory.readTask "task.md" stream
+        let! task = MarkdownDirectory.readTask expectedTask.StorageState.FileName stream
         Assert.Equal(expectedTask, task)
     }
 

--- a/Praefectus.Tests/Storage/MarkdownDirectoryTests.fs
+++ b/Praefectus.Tests/Storage/MarkdownDirectoryTests.fs
@@ -13,14 +13,14 @@ let private emptyTask = Task.Empty<_> { FileName = "" }
 
 let private testDatabase = {
     Tasks = [| {
-        Id = None
+        Id = Some "id"
         Order = Some 1
-        Name = Some "task"
+        Name = None
         Title = None
         Description = Some "Foo bar baz"
         Status = Some TaskStatus.Open
         DependsOn = Array.empty
-        StorageState = { FileName = "1.task.md" }
+        StorageState = { FileName = "1.id.md" }
     } |]
 }
 
@@ -46,9 +46,9 @@ module ReadTaskTests =
     let ``readTask should parse text``(): unit =
         let content = "Foo bar baz"
         let task = {
-            Id = None
+            Id = Some "task"
             Order = None
-            Name = Some "task"
+            Name = None
             Title = None
             Description = Some content
             Status = None
@@ -61,9 +61,9 @@ module ReadTaskTests =
     [<Fact>]
     let ``readTask should read task title from Markdown``(): unit =
         let task = {
-            Id = None
+            Id = Some "task"
             Order = None
-            Name = Some "task"
+            Name = None
             Title = Some "Task title"
             Description = Some "Task content."
             Status = None

--- a/Praefectus.Tests/TestFramework/ConsoleTestUtils.fs
+++ b/Praefectus.Tests/TestFramework/ConsoleTestUtils.fs
@@ -2,15 +2,13 @@
 
 open System
 open System.IO
-open System.Reflection
 
+open Praefectus.Storage.FileSystemStorage
 open Serilog
 
 open Praefectus.Console
 
 exception private ExitCodeException of code: int
-
-let private testDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
 
 let private runMainWithOutput configuration arguments stdOut =
     let mutable exitCode = None
@@ -30,12 +28,11 @@ let private runMainWithOutput configuration arguments stdOut =
     with
     | :? ExitCodeException as ex -> ex.code
 
-let runMain (arguments: string[]): int =
+let runMain (configuration: Configuration<FileSystemTaskState>) (arguments: string[]): int =
     use stdOut = Console.OpenStandardOutput()
-    let configuration = { DatabaseLocation = testDirectory }
     runMainWithOutput configuration arguments stdOut
 
-let runMainCapturingOutput (configuration: Configuration) (arguments: string[]): int * Stream =
+let runMainCapturingOutput (configuration: Configuration<FileSystemTaskState>) (arguments: string[]): int * Stream =
     let stream = new MemoryStream()
     let exitCode = runMainWithOutput configuration arguments stream
     stream.Position <- 0L

--- a/Praefectus.Tests/TestFramework/DatabaseUtils.fs
+++ b/Praefectus.Tests/TestFramework/DatabaseUtils.fs
@@ -1,0 +1,15 @@
+module Praefectus.Tests.TestFramework.DatabaseUtils
+
+open System.IO
+
+open Praefectus.Core
+open Praefectus.Storage
+open Praefectus.Storage.FileSystemStorage
+
+let saveDatabaseToTempDirectory (database: Database<FileSystemTaskState>): Async<string> = async {
+    let databasePath = Path.GetTempFileName()
+    File.Delete databasePath
+    Directory.CreateDirectory databasePath |> ignore
+    do! MarkdownDirectory.saveDatabase database databasePath
+    return databasePath
+}

--- a/Praefectus.Tests/TestFramework/DiffUtils.fs
+++ b/Praefectus.Tests/TestFramework/DiffUtils.fs
@@ -1,0 +1,22 @@
+﻿module Praefectus.Tests.TestFramework.DiffUtils
+
+open System.Collections.Generic
+
+open Praefectus.Core.Diff
+
+let createPositionedSequence(numberedItems: IReadOnlyList<int * char>) =
+    let maxPosition =
+        if numberedItems.Count = 0 then 0
+        else numberedItems |> Seq.map fst |> Seq.max
+    let itemsByPosition = Map.ofSeq numberedItems
+    { new IPositionedSequence<_> with
+        member _.AllowedToInsertAtArbitraryPlaces = false
+        member _.MaxCoord = maxPosition
+        member _.GetItem coord =
+            Map.tryFind coord itemsByPosition
+        member _.AcceptsOn(coord, item) =
+            match Map.tryFind coord itemsByPosition with
+            | None -> true
+            | Some existingItem when existingItem = item -> true
+            | _ -> false
+    }

--- a/Praefectus.sln
+++ b/Praefectus.sln
@@ -10,6 +10,7 @@ ProjectSection(SolutionItems) = preProject
 	docs\1.development-process.md = docs\1.development-process.md
 	docs\2.configuration.md = docs\2.configuration.md
 	docs\3.data-storage.md = docs\3.data-storage.md
+	docs\4.task-ordering.md = docs\4.task-ordering.md
 EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{8DD1BAFA-86F9-49E2-A1A9-64A4F8C28535}"

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ Documentation
 1. [Development Process][docs.1.development-process]
 2. [Configuration][docs.2.configuration]
 3. [Data Storage][docs.3.data-storage]
+4. [Task Ordering][docs.4.task-ordering]
 
 ### RFCs
 
@@ -239,6 +240,7 @@ And I hope it will be fun to work _with_ Praefectus for the users.
 [docs.1.development-process]: docs/1.development-process.md
 [docs.2.configuration]: docs/2.configuration.md
 [docs.3.data-storage]: docs/3.data-storage.md
+[docs.4.task-ordering]: docs/4.task-ordering.md
 [docs.rfcs.command-line-interface]: docs/rfcs/command-line-interface.md
 [docs.rfcs.tasks-and-attributes]: docs/rfcs/tasks-and-attributes.md
 [docs.rfcs.version-control]: docs/rfcs/version-control.md

--- a/docs/3.data-storage.md
+++ b/docs/3.data-storage.md
@@ -10,7 +10,7 @@ task attributes from the task file names and Markdown content; though, any
 attributes (including the ones that are read from the file name) may be
 overridden by the front matter block.
 
-File name scheme is the following: `[order.][id.]<name>.md`.
+File name scheme is the following: `[order.]<id>[.name].md`.
 
 If the first Markdown block in the file is a level 1 heading, then its contents
 will be read as the task title. Everything else in the file is read as the task
@@ -27,8 +27,8 @@ Some task description.
 ```
 
 This task has the following explicit attributes:
+- `id`: `my-task`
 - `order`: `42`
-- `name`: `my-task`
 - `title`: `Task Title`
 - `dependsOn`: `[123, 465]` (a list with two task ids)
 - `description`: `Some task description.`

--- a/docs/4.task-ordering.md
+++ b/docs/4.task-ordering.md
@@ -1,0 +1,26 @@
+﻿Task Ordering
+=============
+One of the Praefectus features is its ability to reorder the existing tasks. To
+do it, just run the `order` command.
+
+The command will apply the order specified using the ordering configuration.
+Every configuration item declares a group of tasks that should be places on a
+particular place. If, say, you want to see tasks starting from a word
+"important" first, then you're supposed to use the following ordering settings:
+
+```fsharp
+let config = {
+    // …
+    Ordering = [|
+        fun t -> t.Name.Value.StartsWith("important")
+        fun other -> true
+    |]
+}
+```
+
+This will move every "important" task before every other one by changing
+the `order` attribute of these tasks.
+
+When applying the order, Praefectus strives to perform a minimal set of changes
+(since any order change usually leads to a file rename on disk), so it will
+keep gaps in task orders, if they appear after applying the required ordering.

--- a/docs/4.task-ordering.md
+++ b/docs/4.task-ordering.md
@@ -13,13 +13,14 @@ let config = {
     // …
     Ordering = [|
         fun t -> t.Name.Value.StartsWith("important")
-        fun other -> true
     |]
 }
 ```
 
 This will move every "important" task before every other one by changing
 the `order` attribute of these tasks.
+
+Tasks that don't fall into any of the ordering functions will be placed last.
 
 When applying the order, Praefectus strives to perform a minimal set of changes
 (since any order change usually leads to a file rename on disk), so it will

--- a/docs/rfcs/command-line-interface.md
+++ b/docs/rfcs/command-line-interface.md
@@ -41,5 +41,8 @@ Praefectus has certain commands with their own arguments:
 
 - `list [--json]`: will list all the tasks in the current database (optionally
   in a JSON format)
+- `order [--whatif]`: will bring rasks to the specified order,
+  see [Task Ordering][docs.4.task-ordering] for details.
 
+[docs.4.task-ordering]: ../4.task-ordering.md
 [issue-13]: https://github.com/ForNeVeR/praefectus/issues/13


### PR DESCRIPTION
This adds an ability to define task ordering, and reorder the tasks. Praefectus tries to make the smallest possbile file rename when reordering the tasks; it does that by applying a modified version of the Myers' algorithm.

**TODO:**
- [x] CI
- [x] Documentation
- [x] Fix task naming algorithm to not produce names as `1.2..md`

**After merge:**
- [ ] Raise an issue about removal of `IPositionedSequence<'a>.AllowedToInsertAtArbitraryPlaces`