### PR TITLE
CI: enable scheduled rebuilds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,14 +33,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: NuGet Cache
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.fsproj') }}
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.101'
+          dotnet-version: '5.0.x'
 
       - name: Build
         run: dotnet build --configuration Release


### PR DESCRIPTION
This will allow us to early catch any breaking CI configuration changes.

This way, we're able to use more robust versions of actions and SDKs used to perform the build.